### PR TITLE
Retry flaky tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   main:
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     runs-on: ${{ matrix.os }}
 

--- a/tests/Errors.test.ts
+++ b/tests/Errors.test.ts
@@ -32,6 +32,8 @@ import {
   wait,
 } from "./Helpers";
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
 const FIXTURES_DIR = path.join(__dirname, "fixtures", "errors");
 
 async function run(

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -31,6 +31,8 @@ import {
   switchCompilationMode,
 } from "./HotHelpers";
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
 expect.addSnapshotSerializer(stringSnapshotSerializer);
 
 describe("hot", () => {

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -15,6 +15,8 @@ import {
   switchCompilationMode,
 } from "./HotHelpers";
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
 expect.addSnapshotSerializer(stringSnapshotSerializer);
 
 // Note: These tests excessively uses snapshots, since they don’t stop execution on failure.

--- a/tests/SuccessfulMake.test.ts
+++ b/tests/SuccessfulMake.test.ts
@@ -15,6 +15,8 @@ import {
   TEST_ENV,
 } from "./Helpers";
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
 const FIXTURES_DIR = path.join(__dirname, "fixtures");
 
 async function run(


### PR DESCRIPTION
As a stop-gap solution for https://github.com/lydell/elm-watch/issues/3, retrying flaky tests improves confidence by getting those green checkmarks.

The retried tests are logged so I should be able to scrape which ones are the flakiest and improve them over time.

The Windows tests seem to fail consistently in CI though (but not locally) even with retry.