### PR TITLE
Properly clean up between tests

### DIFF
--- a/client/WebSocketMessages.ts
+++ b/client/WebSocketMessages.ts
@@ -56,9 +56,6 @@ export const WebSocketToServerMessage = Decode.fieldsUnion("tag", {
   FocusedTab: Decode.fieldsAuto({
     tag: () => "FocusedTab" as const,
   }),
-  ExitRequested: Decode.fieldsAuto({
-    tag: () => "ExitRequested" as const,
-  }),
 });
 
 export function encodeWebSocketToClientMessage(

--- a/client/client.ts
+++ b/client/client.ts
@@ -345,7 +345,7 @@ function run(): void {
 
   const getNow: GetNow = () => new Date();
 
-  void runTeaProgram<Mutable, Msg, Model, Cmd, undefined>({
+  runTeaProgram<Mutable, Msg, Model, Cmd, undefined>({
     initMutable: initMutable(getNow, targetRoot),
     init: init(getNow()),
     update: (msg: Msg, model: Model): [Model, Array<Cmd>] => {
@@ -362,6 +362,9 @@ function run(): void {
       return [newModel, allCmds];
     },
     runCmd: runCmd(getNow, targetRoot),
+  }).catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error("elm-watch: Unexpectedly exited with error:", error);
   });
 
   // This is great when working on the styling of all statuses.

--- a/client/client.ts
+++ b/client/client.ts
@@ -465,6 +465,8 @@ const initMutable =
       resolvePromise(undefined);
       const message: WebSocketToServerMessage = { tag: "ExitRequested" };
       mutable.webSocket.send(JSON.stringify(message));
+      mutable.removeListeners();
+      targetRoot.remove();
       originalExit();
     };
 
@@ -478,8 +480,8 @@ const initMutable =
           mutable.webSocket.addEventListener("close", () => {
             originalKillMatching(targetName).then(resolve).catch(reject);
           });
-          mutable.removeListeners();
           mutable.webSocket.close();
+          mutable.removeListeners();
           targetRoot.remove();
           resolvePromise(undefined);
         } else {

--- a/client/client.ts
+++ b/client/client.ts
@@ -24,7 +24,6 @@ declare global {
     __ELM_WATCH_ON_INIT: () => void;
     __ELM_WATCH_ON_RENDER: (targetName: string) => void;
     __ELM_WATCH_ON_REACHED_IDLE_STATE: (reason: ReachedIdleStateReason) => void;
-    __ELM_WATCH_EXIT: () => void;
     __ELM_WATCH_KILL_MATCHING: (targetName: RegExp) => Promise<void>;
     __ELM_WATCH_DISCONNECT: (targetName: RegExp) => void;
     __ELM_WATCH_LOG_DEBUG: typeof console.debug;
@@ -108,10 +107,6 @@ window.__ELM_WATCH_RELOAD_PAGE ??= (message) => {
     }
   }
   window.location.reload();
-};
-
-window.__ELM_WATCH_EXIT ??= () => {
-  // Do nothing.
 };
 
 window.__ELM_WATCH_KILL_MATCHING ??= (): Promise<void> => Promise.resolve();
@@ -461,16 +456,6 @@ const initMutable =
     window.__ELM_WATCH_ON_INIT = () => {
       dispatch({ tag: "AppInit" });
       originalOnInit();
-    };
-
-    const originalExit = window.__ELM_WATCH_EXIT;
-    window.__ELM_WATCH_EXIT = () => {
-      resolvePromise(undefined);
-      const message: WebSocketToServerMessage = { tag: "ExitRequested" };
-      mutable.webSocket.send(JSON.stringify(message));
-      mutable.removeListeners();
-      targetRoot.remove();
-      originalExit();
     };
 
     const originalKillMatching = window.__ELM_WATCH_KILL_MATCHING;

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -144,6 +144,10 @@ type Msg =
       handleOutputActionResult: Compile.HandleOutputActionResult;
     }
   | {
+      tag: "ExitRequested";
+      date: Date;
+    }
+  | {
       tag: "GotWatcherEvent";
       date: Date;
       eventName: WatcherEventName;
@@ -312,6 +316,13 @@ export type WebSocketState = {
   webSocketConnections: Array<WebSocketConnection>;
 };
 
+export type HotKillManager = {
+  // You are supposed to pass `undefined` initially. While running, this is
+  // mutated to the function. Once successfully run, it is set back to
+  // `undefined` again.
+  kill: (() => Promise<void>) | undefined;
+};
+
 // This uses something inspired by The Elm Architecture, since it’s all about
 // keeping state (model) and reacting to events (messages).
 export async function run(
@@ -322,18 +333,20 @@ export async function run(
   postprocessWorkerPool: PostprocessWorkerPool,
   webSocketState: WebSocketState | undefined,
   project: Project,
-  portChoice: PortChoice
+  portChoice: PortChoice,
+  hotKillManager: HotKillManager
 ): Promise<HotRunResult> {
   const exitOnError = __ELM_WATCH_EXIT_ON_ERROR in env;
 
-  return runTeaProgram<Mutable, Msg, Model, Cmd, HotRunResult>({
+  const result = await runTeaProgram<Mutable, Msg, Model, Cmd, HotRunResult>({
     initMutable: initMutable(
       env,
       getNow,
       postprocessWorkerPool,
       webSocketState,
       project,
-      portChoice
+      portChoice,
+      hotKillManager
     ),
     init: init(getNow(), restartReasons, project.elmJsonsErrors),
     update: (msg: Msg, model: Model): [Model, Array<Cmd>] => {
@@ -358,6 +371,10 @@ export async function run(
     },
     runCmd: runCmd(env, logger, getNow, exitOnError),
   });
+
+  delete hotKillManager.kill;
+
+  return result;
 }
 
 export async function watchElmWatchJsonOnce(
@@ -400,7 +417,8 @@ const initMutable =
     postprocessWorkerPool: PostprocessWorkerPool,
     webSocketState: WebSocketState | undefined,
     project: Project,
-    portChoice: PortChoice
+    portChoice: PortChoice,
+    hotKillManager: HotKillManager
   ) =>
   (
     dispatch: (msg: Msg) => void,
@@ -491,6 +509,32 @@ const initMutable =
         writeElmWatchStuffJson(mutable);
       })
       .catch(rejectPromise);
+
+    hotKillManager.kill = async () => {
+      dispatch({ tag: "ExitRequested", date: getNow() });
+
+      try {
+        await Promise.all(
+          getFlatOutputs(project).map(({ outputState }) =>
+            outputState.status.tag === "Postprocess"
+              ? outputState.status.kill()
+              : Promise.resolve()
+          )
+        );
+      } catch (unknownError) {
+        const error = toError(unknownError);
+        rejectPromise(toError(error));
+      }
+
+      try {
+        await closeAll(mutable);
+      } catch (unknownError) {
+        const error = toError(unknownError);
+        rejectPromise(toError(error));
+      }
+
+      resolvePromise({ tag: "ExitOnIdle" });
+    };
 
     return mutable;
   };
@@ -628,6 +672,43 @@ function update(
         cmds,
       ];
     }
+
+    case "ExitRequested":
+      // istanbul ignore if
+      if (model.hotState.tag !== "Idle") {
+        return [
+          model,
+          [
+            {
+              tag: "Throw",
+              error: new Error(
+                `Got ExitRequested. Expected hotState to be Idle but it is: ${model.hotState.tag}`
+              ),
+            },
+          ],
+        ];
+      }
+
+      switch (model.nextAction.tag) {
+        // istanbul ignore next
+        case "Restart":
+        // istanbul ignore next
+        case "Compile":
+          return [
+            model,
+            [
+              {
+                tag: "Throw",
+                error: new Error(
+                  `Got ExitRequested. Expected nextAction to be NoAction but it is: ${model.nextAction.tag}`
+                ),
+              },
+            ],
+          ];
+
+        case "NoAction":
+          return runNextAction(msg.date, project, model);
+      }
 
     case "SleepBeforeNextActionDone": {
       const [newModel, cmds] = runNextAction(msg.date, project, model);
@@ -853,7 +934,6 @@ function update(
       switch (result.tag) {
         case "Success":
           return onWebSocketToServerMessage(
-            project,
             model,
             msg.date,
             msg.output,
@@ -2127,7 +2207,6 @@ function compileNextAction(nextAction: NextAction): NextAction {
 }
 
 function onWebSocketToServerMessage(
-  project: Project,
   model: Model,
   date: Date,
   output: WebSocketMessageReceivedOutput,
@@ -2175,45 +2254,6 @@ function onWebSocketToServerMessage(
 
     case "FocusedTab":
       return [model, [{ tag: "WebSocketUpdatePriority", webSocket }]];
-
-    case "ExitRequested":
-      // istanbul ignore if
-      if (model.hotState.tag !== "Idle") {
-        return [
-          model,
-          [
-            {
-              tag: "Throw",
-              error: new Error(
-                `Got ExitRequested. Expected hotState to be Idle but it is: ${model.hotState.tag}`
-              ),
-            },
-          ],
-        ];
-      }
-
-      switch (model.nextAction.tag) {
-        // istanbul ignore next
-        case "Restart":
-        // istanbul ignore next
-        case "Compile":
-          return [
-            model,
-            [
-              {
-                tag: "Throw",
-                error: new Error(
-                  `Got ExitRequested. Expected nextAction to be NoAction but it is: ${model.nextAction.tag}`
-                ),
-              },
-            ],
-          ];
-
-        case "NoAction": {
-          const [newModel, cmds] = runNextAction(date, project, model);
-          return [newModel, [...cmds, { tag: "ExitOnIdle" }]];
-        }
-      }
   }
 }
 

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -513,6 +513,7 @@ const initMutable =
     hotKillManager.kill = async () => {
       dispatch({ tag: "ExitRequested", date: getNow() });
 
+      // istanbul ignore next
       try {
         await Promise.all(
           getFlatOutputs(project).map(({ outputState }) =>
@@ -526,6 +527,7 @@ const initMutable =
         rejectPromise(toError(error));
       }
 
+      // istanbul ignore next
       try {
         await closeAll(mutable);
       } catch (unknownError) {

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -535,6 +535,7 @@ const initMutable =
         rejectPromise(toError(error));
       }
 
+      delete hotKillManager.kill;
       resolvePromise({ tag: "ExitOnIdle" });
     };
 

--- a/src/Run.ts
+++ b/src/Run.ts
@@ -43,7 +43,8 @@ export async function run(
   args: Array<CliArg>,
   restartReasons: Array<Hot.LatestEvent>,
   postprocessWorkerPool: PostprocessWorkerPool,
-  webSocketState: Hot.WebSocketState | undefined
+  webSocketState: Hot.WebSocketState | undefined,
+  hotKillManager: Hot.HotKillManager
 ): Promise<RunResult> {
   const parseResult = ElmWatchJson.findReadAndParse(cwd);
 
@@ -274,7 +275,8 @@ export async function run(
                               tag: "PersistedPort",
                               port: elmWatchStuffJson.port,
                             }
-                          : { tag: "NoPort" }
+                          : { tag: "NoPort" },
+                        hotKillManager
                       );
                       switch (result.tag) {
                         case "ExitOnHandledFatalError":

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Env } from "./Env";
 import * as Help from "./Help";
 import { ReadStream, unknownErrorToString, WriteStream } from "./Helpers";
+import { HotKillManager } from "./Hot";
 import { init } from "./Init";
 import { makeLogger } from "./Logger";
 import { absolutePathFromString } from "./PathHelpers";
@@ -15,6 +16,7 @@ type Options = {
   stdout: WriteStream;
   stderr: WriteStream;
   logDebug: (message: string) => void;
+  hotKillManager?: HotKillManager;
 };
 
 export async function elmWatchCli(
@@ -26,6 +28,7 @@ export async function elmWatchCli(
     stdout,
     stderr,
     logDebug,
+    hotKillManager = { kill: undefined },
   }: Options
 ): Promise<number> {
   const getNow: GetNow = () => new Date();
@@ -82,7 +85,8 @@ export async function elmWatchCli(
               result === undefined
                 ? new PostprocessWorkerPool(reject)
                 : result.postprocessWorkerPool,
-              result === undefined ? undefined : result.webSocketState
+              result === undefined ? undefined : result.webSocketState,
+              hotKillManager
             );
           } while (result.tag === "Restart");
           switch (result.tag) {

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -23,7 +23,7 @@ import {
 } from "./Helpers";
 import {
   assertDebugger,
-  cleanupBeforeEachTest,
+  cleanupAfterEachTest,
   expandUi,
   failInit,
   FIXTURES_DIR,
@@ -36,7 +36,7 @@ jest.retryTimes(2, { logErrorsBeforeRetry: true });
 expect.addSnapshotSerializer(stringSnapshotSerializer);
 
 describe("hot", () => {
-  beforeEach(cleanupBeforeEachTest);
+  afterEach(cleanupAfterEachTest);
 
   test("successful connect (collapsed)", async () => {
     const { terminal, renders, div } = await run({

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -638,12 +638,15 @@ describe("hot", () => {
         args: ["WrongVersion"],
         scripts: ["WrongVersion.js"],
         init: failInit,
-        onIdle: () => {
+        onIdle: async () => {
           send({
             tag: "ChangedCompilationMode",
             compilationMode: "optimize",
           });
-          return "Stop";
+          // Wait for the above message to be processed before stopping (needed
+          // for code coverage).
+          await wait(100);
+          return "Stop" as const;
         },
       });
 

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -946,7 +946,7 @@ describe("hot", () => {
         The compiled JavaScript code running in the browser seems to have sent a message that the web socket server cannot recognize!
 
         At root["tag"]:
-        Expected one of these tags: "ChangedCompilationMode", "FocusedTab", "ExitRequested"
+        Expected one of these tags: "ChangedCompilationMode", "FocusedTab"
         Got: "Nope"
 
         The web socket code I generate is supposed to always send correct messages, so something is up here.
@@ -1208,7 +1208,7 @@ describe("hot", () => {
       },
     });
 
-    window.__ELM_WATCH_EXIT();
+    await window.__ELM_WATCH_KILL_MATCHING(/^/);
 
     expect(terminal).toMatchInlineSnapshot(`
       ⏳ Dependencies

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -1366,7 +1366,7 @@ describe("hot", () => {
     }
   });
 
-  test("changes to elm.json", async () => {
+  test.skip("changes to elm.json", async () => {
     const fixture = "changes-to-elm-json";
     const dir = path.join(FIXTURES_DIR, fixture);
     const elmJsonPath = path.join(dir, "elm.json");
@@ -1679,7 +1679,7 @@ describe("hot", () => {
     }
   });
 
-  test("changes to elm.json – typecheck only", async () => {
+  test.skip("changes to elm.json – typecheck only", async () => {
     const fixture = "changes-to-elm-json";
     const dir = path.join(FIXTURES_DIR, fixture);
     const elmJsonPath = path.join(dir, "elm.json");

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -1366,7 +1366,7 @@ describe("hot", () => {
     }
   });
 
-  test.skip("changes to elm.json", async () => {
+  test("changes to elm.json", async () => {
     const fixture = "changes-to-elm-json";
     const dir = path.join(FIXTURES_DIR, fixture);
     const elmJsonPath = path.join(dir, "elm.json");
@@ -1679,7 +1679,7 @@ describe("hot", () => {
     }
   });
 
-  test.skip("changes to elm.json – typecheck only", async () => {
+  test("changes to elm.json – typecheck only", async () => {
     const fixture = "changes-to-elm-json";
     const dir = path.join(FIXTURES_DIR, fixture);
     const elmJsonPath = path.join(dir, "elm.json");

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -26,7 +26,18 @@ import {
 const CONTAINER_ID = "elm-watch";
 export const FIXTURES_DIR = path.join(__dirname, "fixtures", "hot");
 
+let watcher: fs.FSWatcher | undefined = undefined;
+
 export function cleanupBeforeEachTest(): void {
+  if (watcher !== undefined) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "cleanupBeforeEachTest: watcher never closed by itself – closing now."
+    );
+    watcher.close();
+    watcher = undefined;
+  }
+
   // eslint-disable-next-line no-console
   console.warn = () => {
     // Disable Elm’s “Compiled in DEV mode” logs.
@@ -269,9 +280,10 @@ export async function run({
         .catch(reject);
     };
 
-    const watcher = fs.watch(build, () => {
+    watcher = fs.watch(build, () => {
       if (absoluteScripts.every(fs.existsSync)) {
-        watcher.close();
+        watcher?.close();
+        watcher = undefined;
         loadBuiltFiles(false);
       }
     });

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -27,10 +27,13 @@ import {
 const CONTAINER_ID = "elm-watch";
 export const FIXTURES_DIR = path.join(__dirname, "fixtures", "hot");
 
+let cleanupCounter = 0;
 let watcher: fs.FSWatcher | undefined = undefined;
 const hotKillManager: HotKillManager = { kill: undefined };
 
 export async function cleanupAfterEachTest(): Promise<void> {
+  cleanupCounter++;
+
   if (window.__ELM_WATCH_KILL_MATCHING !== undefined) {
     // The idea is that we need no logging here – it’ll just result in double
     // logging since there will most likely be a running server as well.
@@ -40,7 +43,8 @@ export async function cleanupAfterEachTest(): Promise<void> {
   if (watcher !== undefined) {
     // eslint-disable-next-line no-console
     console.error(
-      "cleanupAfterEachTest: watcher never closed by itself – closing now."
+      "cleanupAfterEachTest: watcher never closed by itself – closing now.",
+      cleanupCounter
     );
     watcher.close();
     watcher = undefined;
@@ -48,7 +52,10 @@ export async function cleanupAfterEachTest(): Promise<void> {
 
   if (hotKillManager.kill !== undefined) {
     // eslint-disable-next-line no-console
-    console.error("cleanupAfterEachTest: elm-watch never finished – killing.");
+    console.error(
+      "cleanupAfterEachTest: elm-watch never finished – killing.",
+      cleanupCounter
+    );
     await hotKillManager.kill();
   }
 

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -32,7 +32,8 @@ const hotKillManager: HotKillManager = { kill: undefined };
 
 export async function cleanupAfterEachTest(): Promise<void> {
   if (window.__ELM_WATCH_KILL_MATCHING !== undefined) {
-    // TODO: Do we want some logging here?
+    // The idea is that we need no logging here – it’ll just result in double
+    // logging since there will most likely be a running server as well.
     await window.__ELM_WATCH_KILL_MATCHING(/^/);
   }
 

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -27,12 +27,11 @@ import {
 const CONTAINER_ID = "elm-watch";
 export const FIXTURES_DIR = path.join(__dirname, "fixtures", "hot");
 
-let cleanupCounter = 0;
 let watcher: fs.FSWatcher | undefined = undefined;
 const hotKillManager: HotKillManager = { kill: undefined };
 
 export async function cleanupAfterEachTest(): Promise<void> {
-  cleanupCounter++;
+  const { currentTestName } = expect.getState();
 
   if (window.__ELM_WATCH_KILL_MATCHING !== undefined) {
     // The idea is that we need no logging here – it’ll just result in double
@@ -43,8 +42,8 @@ export async function cleanupAfterEachTest(): Promise<void> {
   if (watcher !== undefined) {
     // eslint-disable-next-line no-console
     console.error(
-      "cleanupAfterEachTest: watcher never closed by itself – closing now.",
-      cleanupCounter
+      "cleanupAfterEachTest: watcher never closed by itself – closing now. Test:",
+      currentTestName
     );
     watcher.close();
     watcher = undefined;
@@ -53,8 +52,8 @@ export async function cleanupAfterEachTest(): Promise<void> {
   if (hotKillManager.kill !== undefined) {
     // eslint-disable-next-line no-console
     console.error(
-      "cleanupAfterEachTest: elm-watch never finished – killing.",
-      cleanupCounter
+      "cleanupAfterEachTest: elm-watch never finished – killing. Test:",
+      currentTestName
     );
     await hotKillManager.kill();
   }

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -30,7 +30,7 @@ export const FIXTURES_DIR = path.join(__dirname, "fixtures", "hot");
 let watcher: fs.FSWatcher | undefined = undefined;
 const hotKillManager: HotKillManager = { kill: undefined };
 
-export async function cleanupBeforeEachTest(): Promise<void> {
+export async function cleanupAfterEachTest(): Promise<void> {
   if (window.__ELM_WATCH_KILL_MATCHING !== undefined) {
     // TODO: Do we want some logging here?
     await window.__ELM_WATCH_KILL_MATCHING(/^/);
@@ -39,7 +39,7 @@ export async function cleanupBeforeEachTest(): Promise<void> {
   if (watcher !== undefined) {
     // eslint-disable-next-line no-console
     console.error(
-      "cleanupBeforeEachTest: watcher never closed by itself – closing now."
+      "cleanupAfterEachTest: watcher never closed by itself – closing now."
     );
     watcher.close();
     watcher = undefined;
@@ -47,14 +47,10 @@ export async function cleanupBeforeEachTest(): Promise<void> {
 
   if (hotKillManager.kill !== undefined) {
     // eslint-disable-next-line no-console
-    console.error("cleanupBeforeEachTest: elm-watch never finished – killing.");
+    console.error("cleanupAfterEachTest: elm-watch never finished – killing.");
     await hotKillManager.kill();
   }
 
-  // eslint-disable-next-line no-console
-  console.warn = () => {
-    // Disable Elm’s “Compiled in DEV mode” logs.
-  };
   document.getElementById(CONTAINER_ID)?.remove();
   window.history.replaceState(null, "", "/");
 
@@ -115,6 +111,11 @@ export async function run({
   renders: string;
   div: HTMLDivElement;
 }> {
+  // eslint-disable-next-line no-console
+  console.warn = () => {
+    // Disable Elm’s “Compiled in DEV mode” logs.
+  };
+
   const dir = path.join(FIXTURES_DIR, fixture);
   const build = path.join(dir, "build");
   const absoluteScripts = scripts.map((script) => path.join(build, script));

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -33,6 +33,12 @@ export function cleanupBeforeEachTest(): void {
   };
   document.getElementById(CONTAINER_ID)?.remove();
   window.history.replaceState(null, "", "/");
+
+  for (const key of Object.keys(window)) {
+    if (key.startsWith("__ELM_WATCH")) {
+      delete (window as unknown as Record<string, unknown>)[key];
+    }
+  }
 }
 
 let bodyCounter = 0;
@@ -179,12 +185,6 @@ export async function run({
         })
         .catch(reject);
     };
-
-    for (const key of Object.keys(window)) {
-      if (key.startsWith("__ELM_WATCH")) {
-        delete (window as unknown as Record<string, unknown>)[key];
-      }
-    }
 
     window.__ELM_WATCH_MOCKED_TIMINGS = true;
 

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -8,7 +8,7 @@ import {
   assertCompilationMode,
   assertDebugDisabled,
   assertDebugger,
-  cleanupBeforeEachTest,
+  cleanupAfterEachTest,
   click,
   FIXTURES_DIR,
   runHotReload,
@@ -22,7 +22,7 @@ expect.addSnapshotSerializer(stringSnapshotSerializer);
 // Note: These tests excessively uses snapshots, since they don’t stop execution on failure.
 // That results in a much better debugging experience (fewer timeouts).
 describe("hot reloading", () => {
-  beforeEach(cleanupBeforeEachTest);
+  afterEach(cleanupAfterEachTest);
 
   test("Html", async () => {
     const { replace, go } = runHotReload({


### PR DESCRIPTION
If tests time out, the elm-watch server is left running, causing Jest not to exit (without `--forceExit`) and causing other tests to fail due to errors from another test. That’s very confusing and annoying. This PR makes sure to tear everything down between tests.