### PR TITLE
Restart when elm-stuff is removed

### DIFF
--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -438,7 +438,7 @@ const initMutable =
 
     const watcher = chokidar.watch(project.watchRoot.absolutePath, {
       ignoreInitial: true,
-      ignored: ["**/elm-stuff/**", "**/node_modules/**"],
+      ignored: /\/(elm-stuff|node_modules)\//,
       disableGlobbing: true,
     });
 

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -438,6 +438,10 @@ const initMutable =
 
     const watcher = chokidar.watch(project.watchRoot.absolutePath, {
       ignoreInitial: true,
+      // Note: Forward slashes must be used here even on Windows. (Using
+      // backslashes on Windows never matches.) The trailing slash is important:
+      // It makes it possible to get notifications of a removed elm-stuff
+      // folder, while ignoring everything that happens _inside_ that folder.
       ignored: /\/(elm-stuff|node_modules)\//,
       disableGlobbing: true,
     });
@@ -1051,6 +1055,20 @@ function onWatcherEvent(
               project
             );
           }
+          return undefined;
+      }
+
+    // Some compiler error messages suggest removing elm-stuff to fix the error.
+    // Restart when that happens.
+    case "elm-stuff":
+      switch (eventName) {
+        case "removed":
+          return makeRestartNextAction(
+            makeWatcherEvent(eventName, absolutePathString, now),
+            project
+          );
+
+        default:
           return undefined;
       }
 

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -455,6 +455,7 @@ const initMutable =
           .catch(rejectPromise);
       },
       (eventName: WatcherEventName, absolutePathString: string): void => {
+        console.log(eventName, absolutePathString);
         dispatch({
           tag: "GotWatcherEvent",
           date: getNow(),

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -455,7 +455,6 @@ const initMutable =
           .catch(rejectPromise);
       },
       (eventName: WatcherEventName, absolutePathString: string): void => {
-        console.log(eventName, absolutePathString);
         dispatch({
           tag: "GotWatcherEvent",
           date: getNow(),

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -1059,7 +1059,9 @@ function onWatcherEvent(
       }
 
     // Some compiler error messages suggest removing elm-stuff to fix the error.
-    // Restart when that happens.
+    // Restart when that happens. Note: This could be a totally unrelated
+    // elm-stuff directory, but I don’t think it’s worth the trouble trying to
+    // check if it affects the project, and possibly logging if it isn’t.
     case "elm-stuff":
       switch (eventName) {
         case "removed":

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -14,6 +14,7 @@ import { LatestEvent, printTimeline } from "../src/Hot";
 import { LoggerConfig } from "../src/Logger";
 import {
   clean,
+  rimraf,
   rm,
   rmSymlink,
   stringSnapshotSerializer,
@@ -1775,6 +1776,99 @@ describe("hot", () => {
 
       ⧙ℹ️ 13:10:05 Changed /Users/you/project/tests/fixtures/hot/changes-to-elm-json/elm.json⧘
       🚨 ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+    `);
+  });
+
+  test("delete elm-stuff", async () => {
+    const fixture = "delete-elm-stuff";
+    const dir = path.join(FIXTURES_DIR, fixture);
+    const elmStuff = path.join(dir, "elm-stuff");
+    const iDat = path.join(elmStuff, "0.19.1", "i.dat");
+    const main = path.join(dir, "src", "Main.elm");
+    const { terminal } = await run({
+      fixture,
+      args: [],
+      scripts: ["Main.js"],
+      isTTY: false,
+      init: (node) => {
+        window.Elm?.Main?.init({ node });
+      },
+      onIdle: async ({ idle }) => {
+        switch (idle) {
+          case 1:
+            fs.writeFileSync(iDat, fs.readFileSync(iDat).subarray(0, 128));
+            touch(main);
+            touch(elmStuff);
+            return "KeepGoing";
+          case 2:
+            await rimraf(elmStuff);
+            return "KeepGoing";
+          default:
+            return "Stop";
+        }
+      },
+    });
+
+    expect(terminal).toMatchInlineSnapshot(`
+      ⏳ Dependencies
+      ✅ Dependencies
+      ⏳ Main: elm make (typecheck only)
+      ✅ Main⧙     1 ms Q | 765 ms T ¦  50 ms W⧘
+
+      📊 ⧙web socket connections:⧘ 0 ⧙(ws://0.0.0.0:59123)⧘
+
+      ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+      ⏳ Main: elm make
+      ✅ Main⧙     1 ms Q | 1.23 s E ¦  55 ms W |   9 ms I⧘
+
+      📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+      ⧙ℹ️ 13:10:05 Web socket connected needing compilation of: Main⧘
+      ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+
+      📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+      ⧙ℹ️ 13:10:05 Web socket disconnected for: Main
+      ℹ️ 13:10:05 Web socket connected for: Main⧘
+      ✅ ⧙13:10:05⧘ Everything up to date.
+      ⏳ Main: elm make
+      🚨 Main
+
+      ⧙-- CORRUPT CACHE ---------------------------------------------------------------⧘
+      ⧙Target: Main⧘
+
+      +-------------------------------------------------------------------------------
+      |  Corrupt File: /Users/you/project/tests/fixtures/hot/delete-elm-stuff/elm-stuff/0.19.1/i.dat
+      |   Byte Offset: 127
+      |       Message: not enough bytes
+      |
+      | Please report this to https://github.com/elm/compiler/issues
+      | Trying to continue anyway.
+      +-------------------------------------------------------------------------------
+
+      It looks like some of the information cached in elm-stuff/ has been corrupted.
+
+      Try deleting your elm-stuff/ directory to get unstuck.
+
+      ⧙Note⧘: This almost certainly means that a 3rd party tool (or editor plugin) is
+      causing problems your the elm-stuff/ directory. Try disabling 3rd party tools
+      one by one until you figure out which it is!
+
+      🚨 ⧙1⧘ error found
+
+      📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+      ⧙ℹ️ 13:10:05 Changed /Users/you/project/tests/fixtures/hot/delete-elm-stuff/src/Main.elm⧘
+      🚨 ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+      ⏳ Dependencies
+      ✅ Dependencies
+      ⏳ Main: elm make
+      ✅ Main⧙     1 ms Q | 1.23 s E ¦  55 ms W |   9 ms I⧘
+
+      📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+      ⧙ℹ️ 13:10:05 Removed /Users/you/project/tests/fixtures/hot/delete-elm-stuff/elm-stuff⧘
+      ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
     `);
   });
 

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -1783,8 +1783,10 @@ describe("hot", () => {
     const fixture = "delete-elm-stuff";
     const dir = path.join(FIXTURES_DIR, fixture);
     const elmStuff = path.join(dir, "elm-stuff");
+    const elmStuff2 = path.join(dir, "src", "elm-stuff");
     const iDat = path.join(elmStuff, "0.19.1", "i.dat");
     const main = path.join(dir, "src", "Main.elm");
+    rm(elmStuff2);
     const { terminal } = await run({
       fixture,
       args: [],
@@ -1798,7 +1800,7 @@ describe("hot", () => {
           case 1:
             fs.writeFileSync(iDat, fs.readFileSync(iDat).subarray(0, 128));
             touch(main);
-            touch(elmStuff);
+            fs.mkdirSync(elmStuff2);
             return "KeepGoing";
           case 2:
             await rimraf(elmStuff);

--- a/tests/fixtures/hot/delete-elm-stuff/elm-watch.json
+++ b/tests/fixtures/hot/delete-elm-stuff/elm-watch.json
@@ -1,0 +1,10 @@
+{
+    "targets": {
+        "Main": {
+            "inputs": [
+                "src/Main.elm"
+            ],
+            "output": "build/Main.js"
+        }
+    }
+}

--- a/tests/fixtures/hot/delete-elm-stuff/elm.json
+++ b/tests/fixtures/hot/delete-elm-stuff/elm.json
@@ -1,0 +1,24 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/tests/fixtures/hot/delete-elm-stuff/src/Main.elm
+++ b/tests/fixtures/hot/delete-elm-stuff/src/Main.elm
@@ -1,0 +1,5 @@
+module Main exposing (main)
+
+import Html
+
+main = Html.text "Main"


### PR DESCRIPTION
Some compiler error messages suggest removing elm-stuff to fix the error. Restart when that happens.