### PR TITLE
Add animation for hot reloads and errors

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -1222,6 +1222,15 @@ function render(
     getIsPositionedInBottomHalf(targetRoot)
   );
 
+  const screenSize = Math.min(window.screen.width, window.screen.height);
+  const windowSize = Math.min(window.innerWidth, window.innerHeight);
+  const size = Math.min(screenSize, 2 * windowSize);
+  targetRoot.style.setProperty("--flash-size", `${size}px`);
+  targetRoot.style.setProperty(
+    "--flash-duration",
+    `${Math.max(0.4, size / 2 / 777).toFixed(2)}s`
+  );
+
   targetRoot.replaceChildren(
     view(
       (msg) => {
@@ -1432,10 +1441,10 @@ time::after {
   position: absolute;
   margin-top: 0.5em;
   margin-left: 0.5em;
-  width: 80vmin;
-  height: 80vmin;
+  width: var(--flash-size);
+  height: var(--flash-size);
   border-radius: 50%;
-  animation: flash 0.7s 0.05s ease-out both;
+  animation: flash var(--flash-duration) 0.05s ease-out both;
   pointer-events: none;
 }
 

--- a/client/client.ts
+++ b/client/client.ts
@@ -1212,13 +1212,15 @@ const CLASS = {
   chevronButton: "chevronButton",
   compilationModeWithIcon: "compilationModeWithIcon",
   container: "container",
-  expandedUiContainer: "expandedUiContainer",
-  shortStatusContainer: "shortStatusContainer",
   debugModeIcon: "debugModeIcon",
+  expandedUiContainer: "expandedUiContainer",
+  flashError: "flashError",
+  flashSuccess: "flashSuccess",
+  root: "root",
+  shortStatusContainer: "shortStatusContainer",
   targetName: "targetName",
   targetRoot: "targetRoot",
   targetRootBottomHalf: "targetRootBottomHalf",
-  root: "root",
 };
 
 const CSS = `
@@ -1363,12 +1365,13 @@ time::after {
   gap: 0.25em;
 }
 
-.${CLASS.shortStatusContainer}::before {
+.${CLASS.flashError}::before,
+.${CLASS.flashSuccess}::before {
   content: "";
   position: absolute;
-  --top: 50%;
-  --left: 50%;
-  transform: translateX(-50%) scale(0);
+  margin-top: 0.5em;
+  margin-left: 0.5em;
+  transform: translate(-50%, -50%) scale(0);
   width: 100vmin;
   height: 100vmin;
   border-radius: 50%;
@@ -1380,14 +1383,14 @@ time::after {
   display: none;
 }
 
-.${CLASS.shortStatusContainer}.Error::before {
+.${CLASS.flashError}::before {
   display: block;
   animation-name: fade;
   background-color: #eb0000;
   #00b600
 }
 
-.${CLASS.shortStatusContainer}.Success::before {
+.${CLASS.flashSuccess}::before {
   display: block;
   animation-name: fade;
   background-color: #00b600;
@@ -1395,7 +1398,7 @@ time::after {
 
 @keyframes fade {
   to {
-    transform: translateX(-50%) scale(1);
+    transform: translate(-50%, -50%) scale(1);
     opacity: 0;
   }
 }
@@ -1437,14 +1440,16 @@ function view(
   const statusTypeChanged = statusData.statusType !== previousStatus;
   previousStatus = statusData.statusType;
 
-  const statusClass: StatusType =
+  const statusClass =
     statusData.statusType === "Success"
       ? statusTypeChanged
-        ? "Success"
-        : "Nothing"
+        ? CLASS.flashSuccess
+        : undefined
       : model.uiExpanded || manageFocus
-      ? "Nothing"
-      : statusData.statusType;
+      ? undefined
+      : statusData.statusType === "Error"
+      ? CLASS.flashError
+      : undefined;
 
   return h(
     HTMLDivElement,
@@ -1455,7 +1460,7 @@ function view(
     h(
       HTMLDivElement,
       {
-        className: `${CLASS.shortStatusContainer} ${statusClass}`,
+        className: CLASS.shortStatusContainer,
         // Placed on the span to increase clickable area.
         onclick: () => {
           dispatch({ tag: "PressedChevron" });
@@ -1473,7 +1478,11 @@ function view(
         )
       ),
       compilationModeIcon(model.compilationMode),
-      icon(statusData.icon, statusData.status),
+      icon(
+        statusData.icon,
+        statusData.status,
+        statusClass === undefined ? {} : { className: statusClass }
+      ),
       h(
         HTMLTimeElement,
         { dateTime: model.status.date.toISOString() },

--- a/client/client.ts
+++ b/client/client.ts
@@ -1563,7 +1563,20 @@ function view(
       icon(
         statusData.icon,
         statusData.status,
-        statusClass === undefined ? {} : { className: statusClass }
+        statusClass === undefined
+          ? {}
+          : {
+              className: statusClass,
+              onanimationend: (event) => {
+                // The animations are designed to work even without this (they
+                // stay on the last frame). We also have `pointer-events: none`.
+                // But remove the absolutely positioned animation element just
+                // in case.
+                if (event.currentTarget instanceof HTMLElement) {
+                  event.currentTarget.classList.remove(statusClass);
+                }
+              },
+            }
       ),
       h(
         HTMLTimeElement,

--- a/client/client.ts
+++ b/client/client.ts
@@ -1431,7 +1431,7 @@ time::after {
   width: 100vmin;
   height: 100vmin;
   border-radius: 50%;
-  animation: flash 1s ease-out forwards;
+  animation: flash 0.8s ease-out forwards;
   pointer-events: none;
 }
 

--- a/client/client.ts
+++ b/client/client.ts
@@ -1264,15 +1264,19 @@ const CLASS = {
 function getStatusClass({
   statusType,
   statusTypeChanged,
+  hasReceivedHotReload,
   uiRelatedUpdate,
 }: {
   statusType: StatusType;
   statusTypeChanged: boolean;
+  hasReceivedHotReload: boolean;
   uiRelatedUpdate: boolean;
 }): string | undefined {
   switch (statusType) {
     case "Success":
-      return statusTypeChanged ? CLASS.flashSuccess : undefined;
+      return statusTypeChanged && hasReceivedHotReload
+        ? CLASS.flashSuccess
+        : undefined;
     case "Error":
       return uiRelatedUpdate ? undefined : CLASS.flashError;
     case "Waiting":
@@ -1515,6 +1519,8 @@ function view(
   const statusClass = getStatusClass({
     statusType,
     statusTypeChanged,
+    hasReceivedHotReload:
+      model.elmCompiledTimestamp !== INITIAL_ELM_COMPILED_TIMESTAMP,
     uiRelatedUpdate: manageFocus,
   });
 

--- a/client/client.ts
+++ b/client/client.ts
@@ -1222,15 +1222,6 @@ function render(
     getIsPositionedInBottomHalf(targetRoot)
   );
 
-  const screenSize = Math.min(window.screen.width, window.screen.height);
-  const windowSize = Math.min(window.innerWidth, window.innerHeight);
-  const size = Math.min(screenSize, 2 * windowSize);
-  targetRoot.style.setProperty("--flash-size", `${size}px`);
-  targetRoot.style.setProperty(
-    "--flash-duration",
-    `${Math.max(0.4, size / 2 / 777).toFixed(2)}s`
-  );
-
   targetRoot.replaceChildren(
     view(
       (msg) => {
@@ -1441,10 +1432,11 @@ time::after {
   position: absolute;
   margin-top: 0.5em;
   margin-left: 0.5em;
-  width: var(--flash-size);
-  height: var(--flash-size);
+  --size: min(500px, 100vmin);
+  width: var(--size);
+  height: var(--size);
   border-radius: 50%;
-  animation: flash var(--flash-duration) 0.05s ease-out both;
+  animation: flash 0.7s 0.05s ease-out both;
   pointer-events: none;
 }
 

--- a/client/client.ts
+++ b/client/client.ts
@@ -1428,10 +1428,10 @@ time::after {
   position: absolute;
   margin-top: 0.5em;
   margin-left: 0.5em;
-  width: 100vmin;
-  height: 100vmin;
+  width: 80vmin;
+  height: 80vmin;
   border-radius: 50%;
-  animation: flash 0.8s ease-out forwards;
+  animation: flash 0.7s 0.05s ease-out both;
   pointer-events: none;
 }
 

--- a/client/client.ts
+++ b/client/client.ts
@@ -366,7 +366,7 @@ function run(): void {
               manageFocus: msg.tag === "UiMsg",
             },
           ]
-        : [];
+        : cmds;
       logDebug(`${msg.tag} (${TARGET_NAME})`, msg, newModel, allCmds);
       return [newModel, allCmds];
     },

--- a/client/client.ts
+++ b/client/client.ts
@@ -1428,35 +1428,50 @@ time::after {
   position: absolute;
   margin-top: 0.5em;
   margin-left: 0.5em;
-  transform: translate(-50%, -50%) scale(0);
   width: 100vmin;
   height: 100vmin;
   border-radius: 50%;
-  animation-duration: 1s;
-  animation-timing-function: ease-out;
-  animation-iteration-count: 1;
-  animation-fill-mode: forwards;
+  animation: flash 1s ease-out forwards;
   pointer-events: none;
-  display: none;
 }
 
 .${CLASS.flashError}::before {
-  display: block;
-  animation-name: fade;
   background-color: #eb0000;
-  #00b600
 }
 
 .${CLASS.flashSuccess}::before {
-  display: block;
-  animation-name: fade;
   background-color: #00b600;
 }
 
-@keyframes fade {
+@keyframes flash {
+  from {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.9;
+  }
+
   to {
     transform: translate(-50%, -50%) scale(1);
     opacity: 0;
+  }
+}
+
+@keyframes nudge {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 0.8;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .${CLASS.flashError}::before,
+  .${CLASS.flashSuccess}::before {
+    transform: translate(-50%, -50%);
+    width: 2em;
+    height: 2em;
+    animation: nudge 0.25s ease-in-out 4 alternate forwards;
   }
 }
 


### PR DESCRIPTION
Only having the 🚨 emoji in the lower left corner can be a bit _too_ subtle for indicating that you are running an older-but-compiling version of your app – it’s easy to miss and be confused.

This PR adds an animation to complement the emoji: A big red circle that grows out from the emoji, and fades away as it goes. I’ve tried hard to tweak it to be noticeable but not annoying. The animation shows as the error state is entered, as well as whenever the window is focused as a reminder.

On top of that, there’s the same animation for successful hot reloads (✅), but green. This makes it easier to tell once the hot reloading has kicked in, which helps when working on styling and you’re unsure if the styling you changed didn’t make any difference or if the hot reloading didn’t kick in.

If the user has configured their OS to “reduce motion”, the animation changes to a more subtle “double blink” over the emoji (no motion, only fading).