### PR TITLE
Handle broken Web Socket connections

### DIFF
--- a/client/WebSocketMessages.ts
+++ b/client/WebSocketMessages.ts
@@ -2,6 +2,10 @@ import * as Decode from "tiny-decoders";
 
 import { CompilationMode } from "../src/Types";
 
+const FocusedTabAcknowledged = Decode.fieldsAuto({
+  tag: () => "FocusedTabAcknowledged" as const,
+});
+
 export type StatusChanged = ReturnType<typeof StatusChanged>;
 const StatusChanged = Decode.fieldsAuto({
   tag: () => "StatusChanged" as const,
@@ -40,6 +44,7 @@ export type WebSocketToClientMessage = ReturnType<
   typeof WebSocketToClientMessage
 >;
 export const WebSocketToClientMessage = Decode.fieldsUnion("tag", {
+  FocusedTabAcknowledged,
   StatusChanged,
   SuccessfullyCompiled,
   SuccessfullyCompiledButRecordFieldsChanged,

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -2317,7 +2317,17 @@ function onWebSocketToServerMessage(
     }
 
     case "FocusedTab":
-      return [model, [{ tag: "WebSocketUpdatePriority", webSocket }]];
+      return [
+        model,
+        [
+          { tag: "WebSocketUpdatePriority", webSocket },
+          {
+            tag: "WebSocketSend",
+            webSocket,
+            message: { tag: "FocusedTabAcknowledged" },
+          },
+        ],
+      ];
   }
 }
 


### PR DESCRIPTION
1. Open a page using elm-watch on iPhone (in Safari). Check that hot reloading works.
2. Go to the home screen and wait a couple of seconds. Note how the “web socket connections: X” counter in the terminal decreases.
3. Open Safari again.

The Web Socket is supposed to reconnect at this point, and hot reloading should work. However:

- We probably missed the Web socket `"close"` event (it happened while the page was in the background).
- The Web Socket might appear to be up, but no messages will be received in either direction.

This PR detects broken connections when coming back to the page, using https://github.com/websockets/ws/tree/975382178f8a9355a5a564bb29cb1566889da9ba#how-to-detect-and-close-broken-connections as a guide.

Note: That guide also mentions pruning broken connections on the backend. I have not found a way to cause leftover connections on the backend – the count seems to always be correct. So this PR only deals with the actual issue I found on iOS.