### PR TITLE
Improve error message for missing default export

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -606,6 +606,8 @@ export function elmWatchNodeDefaultExportNotFunction(
   stdout: string,
   stderr: string
 ): ErrorTemplate {
+  // This is in a variable to avoid a regex in scripts/Build.ts removing the line.
+  const moduleExports = "module.exports";
   return fancyError("MISSING POSTPROCESS DEFAULT EXPORT", scriptPath)`
 I imported your postprocess file:
 
@@ -622,7 +624,7 @@ ${printUnknownValueAsString(imported)}
 Here is a sample function to get you started:
 
 // CJS
-module.exports = async function postprocess({ code, targetName, compilationMode }) {
+${moduleExports} = async function postprocess({ code, targetName, compilationMode }) {
   return code;
 };
 

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -619,6 +619,18 @@ ${bold("imported")} is:
 
 ${printUnknownValueAsString(imported)}
 
+Here is a sample function to get you started:
+
+// CJS
+module.exports = async function postprocess({ code, targetName, compilationMode }) {
+  return code;
+};
+
+// MJS
+export default async function postprocess({ code, targetName, compilationMode }) {
+  return code;
+};
+
 ${printElmWatchNodeStdio(stdout, stderr)}
 `;
 }

--- a/tests/Errors.test.ts
+++ b/tests/Errors.test.ts
@@ -2608,6 +2608,18 @@ describe("errors", () => {
 
         {"default": {}}
 
+        Here is a sample function to get you started:
+
+        // CJS
+        module.exports = async function postprocess({ code, targetName, compilationMode }) {
+          return code;
+        };
+
+        // MJS
+        export default async function postprocess({ code, targetName, compilationMode }) {
+          return code;
+        };
+
         🚨 ⧙1⧘ error found
 
         🚨 Compilation finished in ⧙123 ms⧘⧙ (using 1 elm-watch-node worker).⧘
@@ -2634,6 +2646,18 @@ describe("errors", () => {
         ⧙imported⧘ is:
 
         {"default": Object(1), "postprocess": function "postprocess"}
+
+        Here is a sample function to get you started:
+
+        // CJS
+        module.exports = async function postprocess({ code, targetName, compilationMode }) {
+          return code;
+        };
+
+        // MJS
+        export default async function postprocess({ code, targetName, compilationMode }) {
+          return code;
+        };
 
         STDOUT:
         This is stdout


### PR DESCRIPTION
@jfmengels suggested showing a copy-pastable sample function in the error message.