### PR TITLE
Improve error message and docs for window.Elm and add Web Worker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For a package, it doesn’t take many tests to reach the point where if the test
 
 elm-watch is basically just `elm-watch make`, so the output format is using the good old `window.Elm` global.
 
-elm-watch even _requires `window.Elm` to exist._ That global variable is key to make [hot reloading](#hot-reloading) work.
+elm-watch even _requires `window.Elm` to exist._ That global variable is key to make [hot reloading](#hot-reloading) work. (Technically, `globalThis.Elm` is required to exist. See below.)
 
 **In short:** Keep it simple and load the built Elm JS in its own `<script>` tag and you’ll be fine.
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ elm-watch even _requires `window.Elm` to exist._ That global variable is key to 
 
 **In short:** Keep it simple and load the built Elm JS in its own `<script>` tag and you’ll be fine.
 
-If you’re coming from webpack, Parcel or Vite, you need to update your JavaScript entrypoint like so:
+If you’re coming from [webpack], [Parcel] or [Vite], you need to update your JavaScript entrypoint like so:
 
 ```diff
 -import { Elm } from "./src/Main.elm";

--- a/client/client.ts
+++ b/client/client.ts
@@ -1314,7 +1314,7 @@ function renderWebWorker(model: Model, info: Info): string {
   const statusData = statusIconAndText(model.status, info);
   return `${statusData.icon} elm-watch: ${statusData.status} ${formatTime(
     model.status.date
-  )}`;
+  )} (${info.targetName})`;
 }
 
 function render(

--- a/client/client.ts
+++ b/client/client.ts
@@ -379,8 +379,10 @@ function run(): void {
     runCmd: runCmd(getNow, (dispatch, model, info, manageFocus) => {
       if (targetRoot === undefined) {
         if (model.status.tag !== model.previousStatusTag) {
+          const isError = statusToStatusType(model.status.tag) === "Error";
           // eslint-disable-next-line no-console
-          console.info(renderWebWorker(model, info));
+          const consoleMethod = isError ? console.error : console.info;
+          consoleMethod(renderWebWorker(model, info));
         }
       } else {
         render(getNow, targetRoot, dispatch, model, info, manageFocus);

--- a/client/client.ts
+++ b/client/client.ts
@@ -1139,6 +1139,10 @@ function checkInitializedElmAppsStatus(): InitializedElmAppsStatus {
     };
   }
 
+  if (window.Elm === undefined) {
+    return { tag: "MissingWindowElm" };
+  }
+
   let programTypes;
   try {
     programTypes = ProgramTypes(window);
@@ -1854,6 +1858,7 @@ function viewStatus(
 function idleIcon(status: InitializedElmAppsStatus): string {
   switch (status.tag) {
     case "DecodeError":
+    case "MissingWindowElm":
       return "❌";
 
     case "NoProgramsAtAll":
@@ -1893,6 +1898,9 @@ type InitializedElmAppsStatus =
   | {
       tag: "DecodeError";
       message: string;
+    }
+  | {
+      tag: "MissingWindowElm";
     }
   | {
       tag: "NoProgramsAtAll";
@@ -1949,6 +1957,25 @@ function viewCompilationModeChooser({
           "window.Elm does not look like expected! This is the error message:"
         ),
         h(HTMLPreElement, {}, info.initializedElmAppsStatus.message),
+      ];
+
+    case "MissingWindowElm":
+      return [
+        h(
+          HTMLParagraphElement,
+          {},
+          "elm-watch requires ",
+          h(
+            HTMLAnchorElement,
+            {
+              href: "https://github.com/lydell/elm-watch#windowelm",
+              target: "_blank",
+              rel: "noreferrer",
+            },
+            "window.Elm"
+          ),
+          " to exist, but it is undefined!"
+        ),
       ];
 
     case "NoProgramsAtAll":

--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -1,3 +1,6 @@
+// Support Web Workers, where `window` does not exist.
+const window = globalThis as unknown as Window;
+
 const error: Error & { elmWatchProxy?: true } = new Error(
   `
 Certain parts of \`window.Elm\` aren't available yet! That's fine though!

--- a/example-minimal/index.html
+++ b/example-minimal/index.html
@@ -6,7 +6,7 @@
     <title>example-minimal</title>
   </head>
   <body>
-    <script src="build/main.js"></script>
+    <script src="./build/main.js"></script>
     <script>
       Elm.Main.init({ node: document.body });
     </script>

--- a/example/public/WebWorkerMain.html
+++ b/example/public/WebWorkerMain.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebWorkerMain</title>
+  </head>
+  <body>
+    <p>
+      <input type="text" id="input" />
+      <button type="button" id="send">Send message</button>
+    </p>
+    <p>
+      Last sent message has this many duplicates: <span id="duplicates">0</span>
+    </p>
+    <script>
+      const worker = new Worker("worker.js");
+
+      worker.addEventListener("message", (event) => {
+        duplicates.textContent = event.data;
+      });
+
+      send.onclick = () => {
+        worker.postMessage(input.value);
+        input.value = "";
+      };
+    </script>
+  </body>
+</html>

--- a/example/public/worker.js
+++ b/example/public/worker.js
@@ -1,0 +1,11 @@
+self.importScripts("build/WorkerMain.js");
+
+const app = Elm.WorkerMain.init();
+
+self.addEventListener("message", (event) => {
+  app.ports.fromJs.send(event.data);
+});
+
+app.ports.toJs.subscribe((numDuplicates) => {
+  self.postMessage(numDuplicates);
+});

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -33,7 +33,7 @@ function _Platform_initialize(programType, debugMetadata, flagDecoder, args, ini
 	$elm$core$Result$isOk(flagResult) || _Debug_crash(2 /**/, _Json_errorToString(flagResult.a) /**/);
 	var managers = {};
 	var initUrl = programType === "Browser.application" ? _Browser_getUrl() : undefined;
-	window.__ELM_WATCH_INIT_URL = initUrl;
+	globalThis.__ELM_WATCH_INIT_URL = initUrl;
 	var initPair = init(flagResult.a);
 	var model = initPair.a;
 	var stepper = stepperBuilder(sendToApp, model);
@@ -96,7 +96,7 @@ function _Platform_initialize(programType, debugMetadata, flagDecoder, args, ini
 		if (typeof $elm$browser$Debugger$Main$wrapInit !== "undefined") {
 			init = A3($elm$browser$Debugger$Main$wrapInit, _Json_wrap(newData.debugMetadata), initPair.a.popout, init);
 		}
-		window.__ELM_WATCH_INIT_URL = initUrl;
+		globalThis.__ELM_WATCH_INIT_URL = initUrl;
 		var newInitPair = init(newFlagResult.a);
 		if (!_Utils_eq_elmWatchInternal(initPair, newInitPair)) {
 			return { tag: "ReloadPage", reason: "\`" + moduleName + ".init\` returned something different than last time. Let's start fresh!" };
@@ -297,7 +297,7 @@ function _Platform_mergeExportsElmWatch(moduleName, obj, exports)
 				obj.init = function() {
 					var app = exports.init.apply(exports, arguments);
 					obj.__elmWatchApps.push(app);
-					window.__ELM_WATCH_ON_INIT();
+					globalThis.__ELM_WATCH_ON_INIT();
 					return app;
 				};
 			}
@@ -312,7 +312,7 @@ function _Platform_mergeExportsElmWatch(moduleName, obj, exports)
 
   // ### _Browser_application
   // Don’t pluck things out of `impl`. Pass `impl` to `_Browser_document`. Init
-  // with URL given from `_Platform_initialize` (via `window.__ELM_WATCH_INIT_URL`).
+  // with URL given from `_Platform_initialize` (via `globalThis.__ELM_WATCH_INIT_URL`).
   _Browser_application: `
 // This function was slightly modified by elm-watch.
 function _Browser_application(impl)
@@ -352,7 +352,7 @@ function _Browser_application(impl)
 		%init%: function(flags)
 		{
 			// return A3(impl.init, flags, _Browser_getUrl(), key); // commented out by elm-watch
-			return A3(impl.%init%, flags, window.__ELM_WATCH_INIT_URL, key); // added by elm-watch
+			return A3(impl.%init%, flags, globalThis.__ELM_WATCH_INIT_URL, key); // added by elm-watch
 		},
 		// view: impl.view, // commented out by elm-watch
 		// update: impl.update, // commented out by elm-watch

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -3588,10 +3588,7 @@ describe("hot", () => {
       web socket ws://localhost:59123
       updated 2022-02-05 13:10:05
       status Successfully compiled
-      window.Elm does not look like expected! This is the error message:
-      At root["Elm"]:
-      Expected an object
-      Got: undefined
+      elm-watch requires [window.Elm](https://github.com/lydell/elm-watch#windowelm) to exist, but it is undefined!
       ▲ ❌ 13:10:05 Main
     `);
   });

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -3556,6 +3556,46 @@ describe("hot", () => {
     }
   });
 
+  test("missing window.Elm", async () => {
+    const { renders } = await run({
+      fixture: "missing-window-elm",
+      args: ["Main"],
+      scripts: ["Main.js"],
+      init: () => {
+        expect(window.Elm).toBeUndefined();
+      },
+      onIdle: () => {
+        expandUi();
+        return "Stop";
+      },
+    });
+
+    expect(renders).toMatchInlineSnapshot(`
+      ▼ 🔌 13:10:05 Main
+      ================================================================================
+      ▼ ⏳ 13:10:05 Main
+      ================================================================================
+      ▼ ⏳ 13:10:05 Main
+      ================================================================================
+      ▼ 🔌 13:10:05 Main
+      ================================================================================
+      ▼ ⏳ 13:10:05 Main
+      ================================================================================
+      ▼ ❌ 13:10:05 Main
+      ================================================================================
+      target Main
+      elm-watch %VERSION%
+      web socket ws://localhost:59123
+      updated 2022-02-05 13:10:05
+      status Successfully compiled
+      window.Elm does not look like expected! This is the error message:
+      At root["Elm"]:
+      Expected an object
+      Got: undefined
+      ▲ ❌ 13:10:05 Main
+    `);
+  });
+
   describe("printTimeline", () => {
     function print(
       events: Array<LatestEvent>,

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -561,7 +561,7 @@ function* walkTextNodes(element: Node): Generator<string, void, void> {
   for (const node of element.childNodes) {
     if (node instanceof Text) {
       yield " ";
-      yield node.data;
+      yield node.data.trim();
     } else if (node instanceof HTMLInputElement && node.type === "radio") {
       yield (node.checked ? "◉" : "◯") + (node.disabled ? " (disabled)" : "");
     } else if (node instanceof HTMLButtonElement) {
@@ -569,10 +569,11 @@ function* walkTextNodes(element: Node): Generator<string, void, void> {
       if (textContent.length === 1) {
         yield textContent;
       } else {
-        yield "\n[";
-        yield textContent;
-        yield "]";
+        yield `\n[${textContent}]`;
       }
+    } else if (node instanceof HTMLAnchorElement) {
+      const textContent = (node.textContent ?? "").trim();
+      yield ` [${textContent}](${node.href})`;
     } else {
       yield* walkTextNodes(node);
     }

--- a/tests/fixtures/hot/missing-window-elm/elm-watch.json
+++ b/tests/fixtures/hot/missing-window-elm/elm-watch.json
@@ -1,0 +1,11 @@
+{
+    "postprocess": ["elm-watch-node", "postprocess.js"],
+    "targets": {
+        "Main": {
+            "inputs": [
+                "src/Main.elm"
+            ],
+            "output": "build/Main.js"
+        }
+    }
+}

--- a/tests/fixtures/hot/missing-window-elm/elm.json
+++ b/tests/fixtures/hot/missing-window-elm/elm.json
@@ -1,0 +1,24 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/tests/fixtures/hot/missing-window-elm/postprocess.js
+++ b/tests/fixtures/hot/missing-window-elm/postprocess.js
@@ -1,0 +1,6 @@
+module.exports = function postprocess({ code }) {
+  // Make the Elm JS put `.Elm` on a local object instead of on `window`.
+  // This can happen if you try to `import` a JS file created by `elm make`
+  // and your bundler rewrites `this`.
+  return code.replace(/\bthis\b([\W\s]+)$/, "{}$1");
+};

--- a/tests/fixtures/hot/missing-window-elm/src/Main.elm
+++ b/tests/fixtures/hot/missing-window-elm/src/Main.elm
@@ -1,0 +1,5 @@
+module Main exposing (main)
+
+import Html
+
+main = Html.text "Main"


### PR DESCRIPTION
Another way to put this is: Improve how the global object is used in elm-watch. Don’t assume that `window` exists.