### PR TITLE
Provide better error messages when Elm crashes

### DIFF
--- a/src/Compile.ts
+++ b/src/Compile.ts
@@ -2128,7 +2128,7 @@ export function extractErrors(project: Project): Array<Errors.ErrorTemplate> {
           case "ElmMakeCrashError":
             return Errors.elmMakeCrashError(
               outputPath,
-              status.jsonLength,
+              status.beforeError,
               status.error,
               status.command
             );

--- a/src/Compile.ts
+++ b/src/Compile.ts
@@ -904,7 +904,7 @@ function onCompileSuccess(
             fs.writeFileSync(
               outputPath.theOutputPath.absolutePath,
               // This will inject `elmCompiledTimestamp` into the built
-              // code, which is later used to detect if recompiles are
+              // code, which is later used to detect if recompilations are
               // needed or not. Note: This needs to be the timestamp of
               // when Elm finished compiling, not when postprocessing
               // finished. That’s because we haven’t done the
@@ -1802,6 +1802,7 @@ function statusLine(
     case "ElmWatchNodeDefaultExportNotFunction":
     case "ElmWatchNodeRunError":
     case "ElmWatchNodeBadReturnValue":
+    case "ElmMakeCrashError":
     case "ElmMakeJsonParseError":
     case "ElmMakeError":
     case "ElmJsonReadAsJsonError":
@@ -2122,6 +2123,14 @@ export function extractErrors(project: Project): Array<Errors.ErrorTemplate> {
               status.returnValue,
               status.stdout,
               status.stderr
+            );
+
+          case "ElmMakeCrashError":
+            return Errors.elmMakeCrashError(
+              outputPath,
+              status.jsonLength,
+              status.error,
+              status.command
             );
 
           case "ElmMakeJsonParseError":

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -681,17 +681,20 @@ ${printElmWatchNodeStdio(stdout, stderr)}
 
 export function elmMakeCrashError(
   outputPath: OutputPath | { tag: "NoLocation" },
-  jsonLength: number,
+  jsonLength: number | undefined,
   error: string,
   command: Command
 ): ErrorTemplate {
+  const middle =
+    jsonLength === undefined
+      ? "Elm crashed with this error:"
+      : `I got back ${jsonLength.toString()} characters of JSON, but then Elm crashed with this error:`;
   return fancyError("ELM CRASHED", outputPath)`
 I ran the following commands:
 
 ${printCommand(command)}
 
-I got back ${jsonLength.toString()} characters of JSON,
-but then Elm crashed with this error:
+${middle}
 
 ${error}
 `;

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -679,6 +679,24 @@ ${printElmWatchNodeStdio(stdout, stderr)}
 `;
 }
 
+export function elmMakeCrashError(
+  outputPath: OutputPath | { tag: "NoLocation" },
+  jsonLength: number,
+  error: string,
+  command: Command
+): ErrorTemplate {
+  return fancyError("ELM CRASHED", outputPath)`
+I ran the following commands:
+
+${printCommand(command)}
+
+I got back ${jsonLength.toString()} characters of JSON,
+but then Elm crashed with this error:
+
+${error}
+`;
+}
+
 export function elmMakeJsonParseError(
   outputPath: OutputPath | { tag: "NoLocation" },
   error: JsonError,

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -679,22 +679,46 @@ ${printElmWatchNodeStdio(stdout, stderr)}
 `;
 }
 
+export type ElmMakeCrashBeforeError =
+  | {
+      tag: "Json";
+      length: number;
+    }
+  | {
+      tag: "Text";
+      text: string;
+    };
+
+function printElmMakeCrashBeforeError(
+  beforeError: ElmMakeCrashBeforeError
+): string {
+  switch (beforeError.tag) {
+    case "Json":
+      return `I got back ${beforeError.length.toString()} characters of JSON, but then Elm crashed with this error:`;
+
+    case "Text":
+      return beforeError.text === ""
+        ? "Elm crashed with this error:"
+        : `Elm printed this text:
+
+${beforeError.text}
+
+Then it crashed with this error:`;
+  }
+}
+
 export function elmMakeCrashError(
   outputPath: OutputPath | { tag: "NoLocation" },
-  jsonLength: number | undefined,
+  beforeError: ElmMakeCrashBeforeError,
   error: string,
   command: Command
 ): ErrorTemplate {
-  const middle =
-    jsonLength === undefined
-      ? "Elm crashed with this error:"
-      : `I got back ${jsonLength.toString()} characters of JSON, but then Elm crashed with this error:`;
   return fancyError("ELM CRASHED", outputPath)`
 I ran the following commands:
 
 ${printCommand(command)}
 
-${middle}
+${printElmMakeCrashBeforeError(beforeError)}
 
 ${error}
 `;

--- a/src/SpawnElm.ts
+++ b/src/SpawnElm.ts
@@ -202,7 +202,8 @@ function parsePotentialElmMakeJson(
   stderr: string
 ): RunElmMakeResult | undefined {
   if (!stderr.endsWith("}")) {
-    // This is a workaround for when Elm crashes half-way through printing the JSON.
+    // This is a workaround for when Elm crashes, potentially half-way through printing the JSON.
+    // For example: https://github.com/elm/compiler/issues/1916
     const errorIndex = stderr.lastIndexOf("elm: ");
     if (errorIndex !== -1) {
       return {

--- a/tests/Errors.test.ts
+++ b/tests/Errors.test.ts
@@ -1895,6 +1895,34 @@ describe("errors", () => {
       `);
     });
 
+    test("Elm crash", async () => {
+      expect(await runWithBadElmBin("elm-crash")).toMatchInlineSnapshot(`
+        🚨 app
+
+        ⧙-- TROUBLE WITH JSON REPORT ----------------------------------------------------⧘
+        ⧙Target: app⧘
+
+        I ran the following commands:
+
+        cd /Users/you/project/tests/fixtures/errors/valid
+        elm make --report=json --output=/Users/you/project/tests/fixtures/errors/valid/build/app.js /Users/you/project/tests/fixtures/errors/valid/src/App.elm
+
+        I seem to have gotten some JSON back as expected,
+        but I ran into an error when decoding it:
+
+        Unexpected token 
+         in JSON at position 292
+
+        I wrote that to this file so you can inspect it:
+
+        /Users/you/project/tests/fixtures/errors/valid/elm-watch-ElmMakeJsonParseError-2b1e60ae39a6a6e54939b440e89516b56c0ec80468a3027e18ed9438bb9a5db2.txt
+
+        🚨 ⧙1⧘ error found
+
+        🚨 Compilation finished in ⧙123 ms⧘.
+      `);
+    });
+
     test("interrupt typecheck with compilation error", async () => {
       const fixture = "interrupt-typecheck";
       const dir = path.join(FIXTURES_DIR, fixture);

--- a/tests/Errors.test.ts
+++ b/tests/Errors.test.ts
@@ -1943,6 +1943,34 @@ describe("errors", () => {
       `);
     });
 
+    test("Elm crash with non-JSON printed before", async () => {
+      expect(await runWithBadElmBin("elm-crash-extra")).toMatchInlineSnapshot(`
+        🚨 app
+
+        ⧙-- ELM CRASHED -----------------------------------------------------------------⧘
+        ⧙Target: app⧘
+
+        I ran the following commands:
+
+        cd /Users/you/project/tests/fixtures/errors/valid
+        elm make --report=json --output=/Users/you/project/tests/fixtures/errors/valid/build/app.js /Users/you/project/tests/fixtures/errors/valid/src/App.elm
+
+        Elm printed this text:
+
+        Text before crash
+
+        Then it crashed with this error:
+
+        elm: Map.!: given key is not an element in the map
+        CallStack (from HasCallStack):
+          error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal
+
+        🚨 ⧙1⧘ error found
+
+        🚨 Compilation finished in ⧙123 ms⧘.
+      `);
+    });
+
     test("interrupt typecheck with compilation error", async () => {
       const fixture = "interrupt-typecheck";
       const dir = path.join(FIXTURES_DIR, fixture);

--- a/tests/Errors.test.ts
+++ b/tests/Errors.test.ts
@@ -1895,7 +1895,7 @@ describe("errors", () => {
       `);
     });
 
-    test("Elm crash", async () => {
+    test("Elm crash immediately", async () => {
       expect(await runWithBadElmBin("elm-crash")).toMatchInlineSnapshot(`
         🚨 app
 
@@ -1907,8 +1907,31 @@ describe("errors", () => {
         cd /Users/you/project/tests/fixtures/errors/valid
         elm make --report=json --output=/Users/you/project/tests/fixtures/errors/valid/build/app.js /Users/you/project/tests/fixtures/errors/valid/src/App.elm
 
-        I got back 242 characters of JSON,
-        but then Elm crashed with this error:
+        Elm crashed with this error:
+
+        elm: Map.!: given key is not an element in the map
+        CallStack (from HasCallStack):
+          error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal
+
+        🚨 ⧙1⧘ error found
+
+        🚨 Compilation finished in ⧙123 ms⧘.
+      `);
+    });
+
+    test("Elm crash half-way through printing JSON", async () => {
+      expect(await runWithBadElmBin("elm-crash-json")).toMatchInlineSnapshot(`
+        🚨 app
+
+        ⧙-- ELM CRASHED -----------------------------------------------------------------⧘
+        ⧙Target: app⧘
+
+        I ran the following commands:
+
+        cd /Users/you/project/tests/fixtures/errors/valid
+        elm make --report=json --output=/Users/you/project/tests/fixtures/errors/valid/build/app.js /Users/you/project/tests/fixtures/errors/valid/src/App.elm
+
+        I got back 242 characters of JSON, but then Elm crashed with this error:
 
         elm: Map.!: given key is not an element in the map
         CallStack (from HasCallStack):

--- a/tests/Errors.test.ts
+++ b/tests/Errors.test.ts
@@ -1899,7 +1899,7 @@ describe("errors", () => {
       expect(await runWithBadElmBin("elm-crash")).toMatchInlineSnapshot(`
         🚨 app
 
-        ⧙-- TROUBLE WITH JSON REPORT ----------------------------------------------------⧘
+        ⧙-- ELM CRASHED -----------------------------------------------------------------⧘
         ⧙Target: app⧘
 
         I ran the following commands:
@@ -1907,15 +1907,12 @@ describe("errors", () => {
         cd /Users/you/project/tests/fixtures/errors/valid
         elm make --report=json --output=/Users/you/project/tests/fixtures/errors/valid/build/app.js /Users/you/project/tests/fixtures/errors/valid/src/App.elm
 
-        I seem to have gotten some JSON back as expected,
-        but I ran into an error when decoding it:
+        I got back 242 characters of JSON,
+        but then Elm crashed with this error:
 
-        Unexpected token 
-         in JSON at position 292
-
-        I wrote that to this file so you can inspect it:
-
-        /Users/you/project/tests/fixtures/errors/valid/elm-watch-ElmMakeJsonParseError-2b1e60ae39a6a6e54939b440e89516b56c0ec80468a3027e18ed9438bb9a5db2.txt
+        elm: Map.!: given key is not an element in the map
+        CallStack (from HasCallStack):
+          error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal
 
         🚨 ⧙1⧘ error found
 

--- a/tests/fixtures/errors/valid/bad-bin/elm-crash-extra/elm
+++ b/tests/fixtures/errors/valid/bad-bin/elm-crash-extra/elm
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+if (require("../elm-install")) {
+  process.stderr.write(
+    `Text before crashelm: Map.!: given key is not an element in the map
+CallStack (from HasCallStack):
+  error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal`
+  );
+  process.exit(1);
+}

--- a/tests/fixtures/errors/valid/bad-bin/elm-crash-json/elm
+++ b/tests/fixtures/errors/valid/bad-bin/elm-crash-json/elm
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+if (require("../elm-install")) {
+  process.stderr.write(
+    `{"type":"compile-errors","errors":[{"path":"/Users/you/src/Admin/Main.elm","name":"Admin.Main","problems":[{"title":"MODULE NOT FOUND","region":{"start":{"line":71,"column":8},"end":{"line":71,"column":22}},"message":["You are trying to imporelm: Map.!: given key is not an element in the map
+CallStack (from HasCallStack):
+  error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal`
+  );
+  process.exit(1);
+}

--- a/tests/fixtures/errors/valid/bad-bin/elm-crash/elm
+++ b/tests/fixtures/errors/valid/bad-bin/elm-crash/elm
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+if (require("../elm-install")) {
+  process.stderr.write(
+    `{"type":"compile-errors","errors":[{"path":"/Users/you/src/Admin/Main.elm","name":"Admin.Main","problems":[{"title":"MODULE NOT FOUND","region":{"start":{"line":71,"column":8},"end":{"line":71,"column":22}},"message":["You are trying to imporelm: Map.!: given key is not an element in the map
+CallStack (from HasCallStack):
+  error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal`
+  );
+  process.exit(1);
+}

--- a/tests/fixtures/errors/valid/bad-bin/elm-crash/elm
+++ b/tests/fixtures/errors/valid/bad-bin/elm-crash/elm
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 if (require("../elm-install")) {
   process.stderr.write(
-    `{"type":"compile-errors","errors":[{"path":"/Users/you/src/Admin/Main.elm","name":"Admin.Main","problems":[{"title":"MODULE NOT FOUND","region":{"start":{"line":71,"column":8},"end":{"line":71,"column":22}},"message":["You are trying to imporelm: Map.!: given key is not an element in the map
+    `elm: Map.!: given key is not an element in the map
 CallStack (from HasCallStack):
   error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal`
   );

--- a/tests/fixtures/errors/valid/bad-bin/exit-1-stderr-not-{/elm
+++ b/tests/fixtures/errors/valid/bad-bin/exit-1-stderr-not-{/elm
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 if (require("../elm-install")) {
-  process.stdout.write(`This flag was given a bad value:
+  process.stderr.write(`This flag was given a bad value:
 
     --output=.js
 


### PR DESCRIPTION
Elm can crash with messages like:

```
elm: Map.!: given key is not an element in the map
CallStack (from HasCallStack):
  error, called at ./Data/Map/Internal.hs:610:17 in containers-0.5.11.0-FmkfE5FIiXiCSIJBVRC1nU:Data.Map.Internal
```

And:

```
elm: thread blocked indefinitely in an MVar operation
```

Currently, those result in either:

- A JSON parse error, if the crash happened half-way through printing JSON.
- An “unexpected output” error, if the crash happened before printing JSON.

For JSON parse errors, a .txt file is written as well with all the malformed JSON. Thanks to those files I was able to improve this case. With this PR, those .txt files are no longer written when Elm was detected to crash.

This PR introduces a new “Elm crashed” error.