### PR TITLE
Handle changing target name

### DIFF
--- a/src/Compile.ts
+++ b/src/Compile.ts
@@ -1315,7 +1315,9 @@ async function typecheck({
 
     const proxyFileResult = needsToWriteProxyFile(
       outputPath.theOutputPath,
-      Buffer.from(Inject.versionedIdentifier(webSocketPort))
+      Buffer.from(
+        Inject.versionedIdentifier(outputPath.targetName, webSocketPort)
+      )
     );
 
     switch (proxyFileResult.tag) {

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1400,6 +1400,7 @@ ${joinString(
 )}${extra}
 
 Maybe this target used to exist in elm-watch.json, but you removed or changed it?
+If so, try reloading the page.
   `.trim();
 }
 

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -854,7 +854,7 @@ export function clientCode(
     DEBUG: debug.toString(),
   };
   return (
-    versionedIdentifier(webSocketPort) +
+    versionedIdentifier(outputPath.targetName, webSocketPort) +
     ClientCode.client.replace(
       new RegExp(`%(${join(Object.keys(replacements), "|")})%`, "g"),
       (match: string, name: string) =>
@@ -868,10 +868,15 @@ export function clientCode(
 // - The output exists.
 // - And it was created by `elm-watch hot`. (`elm-watch make` output does not contain WebSocket stuff).
 // - And it was created by the same version of `elm-watch`. (Older versions could have bugs.)
+// - And it has the same target name. (It might have changed, and needs to match.)
 // - And it used the same WebSocket port. (Otherwise it will never connect to us.)
-export function versionedIdentifier(webSocketPort: Port): string {
+export function versionedIdentifier(
+  targetName: string,
+  webSocketPort: Port
+): string {
   return `// elm-watch hot ${JSON.stringify({
     version: "%VERSION%",
+    targetName,
     webSocketPort: webSocketPort.thePort,
   })}\n`;
 }

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -869,6 +869,7 @@ describe("hot", () => {
         Disabled2
 
         Maybe this target used to exist in elm-watch.json, but you removed or changed it?
+        If so, try reloading the page.
         ▲ ❌ 13:10:05 Enabled1
       `);
     });
@@ -918,6 +919,7 @@ describe("hot", () => {
         Main
 
         Maybe this target used to exist in elm-watch.json, but you removed or changed it?
+        If so, try reloading the page.
         ▲ ❌ 13:10:05 Main
       `);
     });

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -924,6 +924,160 @@ describe("hot", () => {
       `);
     });
 
+    test("change target name", async () => {
+      const fixture = "change-target-name";
+      const dir = path.join(FIXTURES_DIR, fixture);
+      const elmWatchJsonPath = path.join(dir, "elm-watch.json");
+      const elmWatchJsonTemplatePath = path.join(
+        dir,
+        "elm-watch.template.json"
+      );
+      const elmWatchJsonString = fs.readFileSync(
+        elmWatchJsonTemplatePath,
+        "utf8"
+      );
+      fs.writeFileSync(elmWatchJsonPath, elmWatchJsonString);
+
+      const { terminal, renders } = await run({
+        fixture,
+        scripts: ["Main.js"],
+        isTTY: false,
+        init: (node) => {
+          try {
+            window.Elm?.Main?.init({ node });
+          } catch {
+            // Ignore elm-watch proxy “error” on reload.
+          }
+        },
+        onIdle: ({ idle }) => {
+          switch (idle) {
+            case 1:
+              fs.writeFileSync(
+                elmWatchJsonPath,
+                elmWatchJsonString.replace("Main", "Renamed")
+              );
+              return "KeepGoing";
+            case 2:
+              expandUi();
+              window.__ELM_WATCH.RELOAD_PAGE(undefined);
+              return "KeepGoing";
+            default:
+              return "Stop";
+          }
+        },
+      });
+
+      expect(terminal).toMatchInlineSnapshot(`
+        ⏳ Dependencies
+        ✅ Dependencies
+        ⏳ Main: elm make (typecheck only)
+        ✅ Main⧙     1 ms Q | 765 ms T ¦  50 ms W⧘
+
+        📊 ⧙web socket connections:⧘ 0 ⧙(ws://0.0.0.0:59123)⧘
+
+        ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+        ⏳ Main: elm make
+        ✅ Main⧙     1 ms Q | 1.23 s E ¦  55 ms W |   9 ms I⧘
+
+        📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+        ⧙ℹ️ 13:10:05 Web socket connected needing compilation of: Main⧘
+        ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+
+        📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+        ⧙ℹ️ 13:10:05 Web socket disconnected for: Main
+        ℹ️ 13:10:05 Web socket connected for: Main⧘
+        ✅ ⧙13:10:05⧘ Everything up to date.
+        ⏳ Dependencies
+        ✅ Dependencies
+        ⏳ Renamed: elm make (typecheck only)
+        ✅ Renamed⧙     1 ms Q | 765 ms T ¦  50 ms W⧘
+
+        📊 ⧙web socket connections:⧘ 0 ⧙(ws://0.0.0.0:59123)⧘
+
+        ⧙ℹ️ 13:10:05 Changed /Users/you/project/tests/fixtures/hot/change-target-name/elm-watch.json⧘
+        ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+
+        📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+        ⧙ℹ️ 13:10:05 Web socket connected with errors (see the browser for details)⧘
+        ✅ ⧙13:10:05⧘ Everything up to date.
+        ⏳ Renamed: elm make
+        ✅ Renamed⧙     1 ms Q | 1.23 s E ¦  55 ms W |   9 ms I⧘
+
+        📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+        ⧙ℹ️ 13:10:05 Web socket disconnected for: (no matching target)
+        ℹ️ 13:10:05 Web socket connected needing compilation of: Renamed⧘
+        ✅ ⧙13:10:05⧘ Compilation finished in ⧙123 ms⧘.
+
+        📊 ⧙web socket connections:⧘ 1 ⧙(ws://0.0.0.0:59123)⧘
+
+        ⧙ℹ️ 13:10:05 Web socket disconnected for: Renamed
+        ℹ️ 13:10:05 Web socket connected for: Renamed⧘
+        ✅ ⧙13:10:05⧘ Everything up to date.
+      `);
+
+      expect(renders).toMatchInlineSnapshot(`
+        ▼ 🔌 13:10:05 Main
+        ================================================================================
+        ▼ ⏳ 13:10:05 Main
+        ================================================================================
+        ▼ ⏳ 13:10:05 Main
+        ================================================================================
+        ▼ 🔌 13:10:05 Main
+        ================================================================================
+        ▼ 🔌 13:10:05 Main
+        ================================================================================
+        ▼ ⏳ 13:10:05 Main
+        ================================================================================
+        ▼ ✅ 13:10:05 Main
+        ================================================================================
+        ▼ ⏳ 13:10:05 Main
+        ================================================================================
+        ▼ 🔌 13:10:05 Main
+        ================================================================================
+        ▼ 🔌 13:10:05 Main
+        ================================================================================
+        ▼ ⏳ 13:10:05 Main
+        ================================================================================
+        target Main
+        elm-watch %VERSION%
+        web socket ws://localhost:59123
+        updated 2022-02-05 13:10:05
+        status Unexpected error
+        I ran into an unexpected error! This is the error message:
+        The compiled JavaScript code running in the browser says it is for this target:
+
+        Main
+
+        But I can't find that target in elm-watch.json!
+
+        These targets are available in elm-watch.json:
+
+        Renamed
+
+        Maybe this target used to exist in elm-watch.json, but you removed or changed it?
+        If so, try reloading the page.
+        ▲ ❌ 13:10:05 Main
+        ================================================================================
+        ▼ 🔌 13:10:05 Renamed
+        ================================================================================
+        ▼ ⏳ 13:10:05 Renamed
+        ================================================================================
+        ▼ ⏳ 13:10:05 Renamed
+        ================================================================================
+        ▼ 🔌 13:10:05 Renamed
+        ================================================================================
+        ▼ 🔌 13:10:05 Renamed
+        ================================================================================
+        ▼ ⏳ 13:10:05 Renamed
+        ================================================================================
+        ▼ ✅ 13:10:05 Renamed
+      `);
+    });
+
     test("target disabled", async () => {
       modifyUrl((url) => {
         url.searchParams.set("targetName", "Html");

--- a/tests/fixtures/hot/change-target-name/.gitignore
+++ b/tests/fixtures/hot/change-target-name/.gitignore
@@ -1,0 +1,1 @@
+elm-watch.json

--- a/tests/fixtures/hot/change-target-name/elm-watch.template.json
+++ b/tests/fixtures/hot/change-target-name/elm-watch.template.json
@@ -1,0 +1,10 @@
+{
+    "targets": {
+        "Main": {
+            "inputs": [
+                "src/Main.elm"
+            ],
+            "output": "build/Main.js"
+        }
+    }
+}

--- a/tests/fixtures/hot/change-target-name/elm.json
+++ b/tests/fixtures/hot/change-target-name/elm.json
@@ -1,0 +1,24 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/tests/fixtures/hot/change-target-name/src/Main.elm
+++ b/tests/fixtures/hot/change-target-name/src/Main.elm
@@ -1,0 +1,5 @@
+module Main exposing (main)
+
+import Html
+
+main = Html.text "Main"


### PR DESCRIPTION
Previously, changing target name meant that you “bricked” your setup – that target could never connect again due to the target name mismatch. You had to delete the compiled JS to get unstuck. This PR changes it so a new JS file is compiled if the target name changes.