### PR TITLE
Handle HTTP caching

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -129,6 +129,7 @@ __ELM_WATCH.ON_REACHED_IDLE_STATE ??= () => {
 __ELM_WATCH.RELOAD_STATUSES ??= {};
 
 const RELOAD_MESSAGE_KEY = "__elmWatchReloadMessage";
+const RELOAD_TARGET_NAME_KEY_PREFIX = "__elmWatchReloadTarget__";
 
 __ELM_WATCH.RELOAD_PAGE ??= (message) => {
   if (message !== undefined) {
@@ -285,6 +286,7 @@ type Model = {
   browserUiPosition: BrowserUiPosition;
   lastBrowserUiPositionChangeDate: Date | undefined;
   elmCompiledTimestamp: number;
+  elmCompiledTimestampBeforeReload: number | undefined;
   uiExpanded: boolean;
 };
 
@@ -332,6 +334,7 @@ type Cmd =
   | {
       tag: "UpdateGlobalStatus";
       reloadStatus: ReloadStatus;
+      elmCompiledTimestamp: number;
     }
   | {
       tag: "WebSocketTimeoutBegin";
@@ -431,12 +434,22 @@ function parseBrowseUiPositionWithFallback(value: unknown): BrowserUiPosition {
 }
 
 function run(): void {
+  let elmCompiledTimestampBeforeReload: number | undefined = undefined;
   try {
     const message = window.sessionStorage.getItem(RELOAD_MESSAGE_KEY);
     if (message !== null) {
       // eslint-disable-next-line no-console
       console.info(message);
       window.sessionStorage.removeItem(RELOAD_MESSAGE_KEY);
+    }
+    const key = RELOAD_TARGET_NAME_KEY_PREFIX + TARGET_NAME;
+    const previous = window.sessionStorage.getItem(key);
+    if (previous !== null) {
+      const number = Number(previous);
+      if (Number.isFinite(number)) {
+        elmCompiledTimestampBeforeReload = number;
+      }
+      window.sessionStorage.removeItem(key);
     }
   } catch {
     // Ignore failing to read or delete from sessionStorage.
@@ -451,7 +464,7 @@ function run(): void {
 
   runTeaProgram<Mutable, Msg, Model, Cmd, undefined>({
     initMutable: initMutable(getNow, elements),
-    init: init(getNow(), browserUiPosition),
+    init: init(getNow(), browserUiPosition, elmCompiledTimestampBeforeReload),
     update: (msg: Msg, model: Model): [Model, Array<Cmd>] => {
       const [updatedModel, cmds] = update(msg, model);
       const modelChanged = updatedModel !== model;
@@ -459,6 +472,13 @@ function run(): void {
         ? {
             ...updatedModel,
             previousStatusTag: model.status.tag,
+            uiExpanded:
+              model.status.tag !== updatedModel.status.tag &&
+              updatedModel.status.tag === "WaitingForReload" &&
+              updatedModel.elmCompiledTimestamp ===
+                updatedModel.elmCompiledTimestampBeforeReload
+                ? true
+                : updatedModel.uiExpanded,
           }
         : model;
       const oldErrorOverlay = getErrorOverlay(model.status);
@@ -468,7 +488,8 @@ function run(): void {
             ...cmds,
             {
               tag: "UpdateGlobalStatus",
-              reloadStatus: statusToReloadStatus(newModel.status),
+              reloadStatus: statusToReloadStatus(newModel),
+              elmCompiledTimestamp: newModel.elmCompiledTimestamp,
             },
             // This needs to be done before Render, since it depends on whether
             // the error overlay is visible or not.
@@ -517,8 +538,8 @@ function getErrorOverlay(status: Status): ErrorOverlay | undefined {
   return "errorOverlay" in status ? status.errorOverlay : undefined;
 }
 
-function statusToReloadStatus(status: Status): ReloadStatus {
-  switch (status.tag) {
+function statusToReloadStatus(model: Model): ReloadStatus {
+  switch (model.status.tag) {
     case "Busy":
     case "Connecting":
       return { tag: "MightWantToReload" };
@@ -532,7 +553,10 @@ function statusToReloadStatus(status: Status): ReloadStatus {
       return { tag: "NoReloadWanted" };
 
     case "WaitingForReload":
-      return { tag: "ReloadRequested", reasons: status.reasons };
+      return model.elmCompiledTimestamp ===
+        model.elmCompiledTimestampBeforeReload
+        ? { tag: "NoReloadWanted" }
+        : { tag: "ReloadRequested", reasons: model.status.reasons };
   }
 }
 
@@ -931,7 +955,8 @@ function initWebSocket(
 
 const init = (
   date: Date,
-  browserUiPosition: BrowserUiPosition
+  browserUiPosition: BrowserUiPosition,
+  elmCompiledTimestampBeforeReload: number | undefined
 ): [Model, Array<Cmd>] => {
   const model: Model = {
     status: { tag: "Connecting", date, attemptNumber: 1 },
@@ -940,6 +965,7 @@ const init = (
     browserUiPosition,
     lastBrowserUiPositionChangeDate: undefined,
     elmCompiledTimestamp: INITIAL_ELM_COMPILED_TIMESTAMP,
+    elmCompiledTimestampBeforeReload,
     uiExpanded: false,
   };
   return [model, [{ tag: "Render", model, manageFocus: false }]];
@@ -1551,6 +1577,20 @@ const runCmd =
 
       case "UpdateGlobalStatus":
         __ELM_WATCH.RELOAD_STATUSES[TARGET_NAME] = cmd.reloadStatus;
+        switch (cmd.reloadStatus.tag) {
+          case "NoReloadWanted":
+          case "MightWantToReload":
+            break;
+          case "ReloadRequested":
+            try {
+              window.sessionStorage.setItem(
+                RELOAD_TARGET_NAME_KEY_PREFIX + TARGET_NAME,
+                cmd.elmCompiledTimestamp.toString()
+              );
+            } catch {
+              // Ignore failing to write to sessionStorage.
+            }
+        }
         reloadPageIfNeeded();
         return;
 
@@ -1835,7 +1875,7 @@ type Info = {
 };
 
 function renderWebWorker(model: Model, info: Info): string {
-  const statusData = statusIconAndText(model.status, info);
+  const statusData = statusIconAndText(model, info);
   return `${statusData.icon} elm-watch: ${statusData.status} ${formatTime(
     model.status.date
   )} (${info.targetName})`;
@@ -2290,8 +2330,8 @@ function view(
     : passedModel;
 
   const statusData: StatusData = {
-    ...statusIconAndText(model.status, info),
-    ...viewStatus(dispatch, model.status, model.compilationMode, info),
+    ...statusIconAndText(model, info),
+    ...viewStatus(dispatch, model, info),
   };
 
   const statusType = statusToStatusType(model.status.tag);
@@ -2534,10 +2574,10 @@ type StatusData = {
 };
 
 function statusIconAndText(
-  status: Status,
+  model: Model,
   info: Info
 ): Pick<StatusData, "icon" | "status"> {
-  switch (status.tag) {
+  switch (model.status.tag) {
     case "Busy":
       return {
         icon: "⏳",
@@ -2587,19 +2627,25 @@ function statusIconAndText(
       };
 
     case "WaitingForReload":
-      return {
-        icon: "⏳",
-        status: "Waiting for reload",
-      };
+      return model.elmCompiledTimestamp ===
+        model.elmCompiledTimestampBeforeReload
+        ? {
+            icon: "❌",
+            status: "Reload trouble",
+          }
+        : {
+            icon: "⏳",
+            status: "Waiting for reload",
+          };
   }
 }
 
 function viewStatus(
   dispatch: (msg: UiMsg) => void,
-  status: Status,
-  compilationMode: CompilationModeWithProxy,
+  model: Model,
   info: Info
 ): Pick<StatusData, "content" | "dl"> {
+  const { status, compilationMode } = model;
   switch (status.tag) {
     case "Busy":
       return {
@@ -2717,13 +2763,19 @@ function viewStatus(
     case "WaitingForReload":
       return {
         dl: [],
-        content: [
-          h(
-            HTMLParagraphElement,
-            {},
-            "Waiting for other targets to finish compiling…"
-          ),
-        ],
+        content:
+          model.elmCompiledTimestamp === model.elmCompiledTimestampBeforeReload
+            ? [
+                "A while ago I reloaded the page to get new compiled JavaScript.",
+                "But it looks like after the last page reload I got the same JavaScript as before, instead of new stuff!",
+                `The old JavaScript was compiled ${new Date(
+                  model.elmCompiledTimestamp
+                ).toLocaleString()}, and so was the JavaScript currently running.`,
+                "I currently need to reload the page again, but fear a reload loop if I try.",
+                "Do you have accidental HTTP caching enabled maybe?",
+                "Try hard refreshing the page and see if that helps, and consider disabling HTTP caching during development.",
+              ].map((text) => h(HTMLParagraphElement, {}, text))
+            : [h(HTMLParagraphElement, {}, "Waiting for other targets…")],
       };
   }
 }
@@ -3451,6 +3503,7 @@ Maybe the JavaScript code running in the browser was compiled with an older vers
       browserUiPosition: "BottomLeft",
       lastBrowserUiPositionChangeDate: undefined,
       elmCompiledTimestamp: 0,
+      elmCompiledTimestampBeforeReload: undefined,
       uiExpanded: true,
     };
     render(

--- a/example/dev-server.js
+++ b/example/dev-server.js
@@ -136,6 +136,19 @@ const servers = [
       }
     },
   },
+  {
+    port: 8008,
+    subdomain: "application-cached",
+    serve: (req, res, log) => {
+      res.setHeader("cache-control", "max-age=3600");
+      serveWithEsbuild(
+        req,
+        res,
+        log,
+        looksLikeFile(req.url) ? req.url : "/ApplicationMain.html"
+      );
+    },
+  },
 ];
 
 function serveWithEsbuild(req, res, log, newUrl) {

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -533,7 +533,7 @@ describe("hot", () => {
     `);
   });
 
-  describe("Parse web socket connect request url errors", () => {
+  describe("Parse WebSocket connect request url errors", () => {
     const originalWebSocket = WebSocket;
     let _lastWebSocket: WebSocket | undefined = undefined;
 
@@ -1134,6 +1134,7 @@ describe("hot", () => {
         WrongVersion
         SendBadJson
         Reconnect
+        HttpCaching
 
         If you want to have this target compiled, restart elm-watch either with more CLI arguments or no CLI arguments at all!
         ▲ ❌ 13:10:05 TargetDisabled

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -4747,6 +4747,108 @@ describe("hot", () => {
     `);
   });
 
+  test("reload trouble with http caching", async () => {
+    const { renders } = await run({
+      fixture: "basic",
+      args: ["HttpCaching"],
+      scripts: ["HttpCaching.js"],
+      simulateHttpCacheOnReload: true,
+      init: (node) => {
+        window.Elm?.HtmlMain?.init({ node });
+      },
+      onIdle: ({ idle }) => {
+        switch (idle) {
+          case 1:
+            switchCompilationMode("optimize");
+            return "KeepGoing";
+          default:
+            return "Stop";
+        }
+      },
+    });
+
+    const cleanedRenders = renders.replace(
+      /compiled .+? and/,
+      "compiled 10/9/2022, 11:36:01 AM, and"
+    );
+
+    expect(cleanedRenders).toMatchInlineSnapshot(`
+      ▼ 🔌 13:10:05 HttpCaching
+      ================================================================================
+      ▼ ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      ▼ ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      ▼ 🔌 13:10:05 HttpCaching
+      ================================================================================
+      ▼ 🔌 13:10:05 HttpCaching
+      ================================================================================
+      ▼ ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      ▼ ✅ 13:10:05 HttpCaching
+      ================================================================================
+      target HttpCaching
+      elm-watch %VERSION%
+      web socket ws://localhost:59123
+      updated 2022-02-05 13:10:05
+      status Successfully compiled
+      Compilation mode
+      ◯ (disabled) Debug The Elm debugger isn't supported by \`Html\` programs.
+      ◉ Standard
+      ◯ Optimize
+      ↑↗
+      ·→
+      ▲ ✅ 13:10:05 HttpCaching
+      ================================================================================
+      target HttpCaching
+      elm-watch %VERSION%
+      web socket ws://localhost:59123
+      updated 2022-02-05 13:10:05
+      status Waiting for compilation
+      Compilation mode
+      ◯ (disabled) Debug The Elm debugger isn't supported by \`Html\` programs.
+      ◯ (disabled) Standard
+      ◉ (disabled) Optimize 🚀
+      ↑↗
+      ·→
+      ▲ 🚀 ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      target HttpCaching
+      elm-watch %VERSION%
+      web socket ws://localhost:59123
+      updated 2022-02-05 13:10:05
+      status Waiting for compilation
+      Compilation mode
+      ◯ (disabled) Debug The Elm debugger isn't supported by \`Html\` programs.
+      ◯ (disabled) Standard
+      ◉ (disabled) Optimize 🚀
+      ↑↗
+      ·→
+      ▲ 🚀 ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      ▼ 🔌 13:10:05 HttpCaching
+      ================================================================================
+      ▼ 🔌 13:10:05 HttpCaching
+      ================================================================================
+      ▼ ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      ▼ 🚀 ⏳ 13:10:05 HttpCaching
+      ================================================================================
+      target HttpCaching
+      elm-watch %VERSION%
+      web socket ws://localhost:59123
+      updated 2022-02-05 13:10:05
+      status Reload trouble
+      A while ago I reloaded the page to get new compiled JavaScript.
+      But it looks like after the last page reload I got the same JavaScript as before, instead of new stuff!
+      The old JavaScript was compiled 10/9/2022, 11:36:01 AM, and so was the JavaScript currently running.
+      I currently need to reload the page again, but fear a reload loop if I try.
+      Do you have accidental HTTP caching enabled maybe?
+      Try hard refreshing the page and see if that helps, and consider disabling HTTP caching during development.
+      ▲ 🚀 ❌ 13:10:05 HttpCaching
+    `);
+  });
+
   describe("printTimeline", () => {
     function print(
       events: Array<LatestEvent>,

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -1632,7 +1632,7 @@ describe("hot reloading", () => {
       web socket ws://localhost:59123
       updated 2022-02-05 13:10:05
       status Waiting for reload
-      Waiting for other targets to finish compiling…
+      Waiting for other targets…
       ▲ 🐛 ⏳ 13:10:05 MultipleTargets
       ================================================================================
       ▼ 🐛 🔌 13:10:05 MultipleTargets
@@ -1824,7 +1824,7 @@ describe("hot reloading", () => {
       web socket ws://localhost:59123
       updated 2022-02-05 13:10:05
       status Waiting for reload
-      Waiting for other targets to finish compiling…
+      Waiting for other targets…
       ▲ 🐛 ⏳ 13:10:05 MultipleTargetsOther1
       ================================================================================
       target MultipleTargets
@@ -1845,7 +1845,7 @@ describe("hot reloading", () => {
       web socket ws://localhost:59123
       updated 2022-02-05 13:10:05
       status Waiting for reload
-      Waiting for other targets to finish compiling…
+      Waiting for other targets…
       ▲ 🐛 ⏳ 13:10:05 MultipleTargetsOther1
       ================================================================================
       target MultipleTargets
@@ -1853,7 +1853,7 @@ describe("hot reloading", () => {
       web socket ws://localhost:59123
       updated 2022-02-05 13:10:05
       status Waiting for reload
-      Waiting for other targets to finish compiling…
+      Waiting for other targets…
       ▲ 🐛 ⏳ 13:10:05 MultipleTargets
       ================================================================================
       ▼ 🐛 🔌 13:10:05 MultipleTargets

--- a/tests/fixtures/hot/basic/elm-watch.json
+++ b/tests/fixtures/hot/basic/elm-watch.json
@@ -65,6 +65,12 @@
                 "src/HtmlMain.elm"
             ],
             "output": "build/Reconnect.js"
+        },
+        "HttpCaching": {
+            "inputs": [
+                "src/HtmlMain.elm"
+            ],
+            "output": "build/HttpCaching.js"
         }
     }
 }


### PR DESCRIPTION
Accidental HTTP caching can cause elm-watch to reload the page in a loop. This PR guards against that and provides a helpful error message.