### PR TITLE
Change websocket path from `/` to `/elm-watch`

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -927,7 +927,7 @@ function initWebSocket(
   const hostname =
     window.location.hostname === "" ? "localhost" : window.location.hostname;
   const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-  const url = new URL(`${protocol}://${hostname}:${WEBSOCKET_PORT}/`);
+  const url = new URL(`${protocol}://${hostname}:${WEBSOCKET_PORT}/elm-watch`);
   url.searchParams.set("elmWatchVersion", VERSION);
   url.searchParams.set("targetName", TARGET_NAME);
   url.searchParams.set("elmCompiledTimestamp", elmCompiledTimestamp.toString());

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -2153,7 +2153,7 @@ type ParseWebSocketConnectRequestUrlResult =
 type ParseWebSocketConnectRequestUrlError =
   | {
       tag: "BadUrl";
-      expectedStart: "/?";
+      expectedStart: "/elm-watch?";
       actualUrlString: string;
     }
   | {
@@ -2183,16 +2183,16 @@ function parseWebSocketConnectRequestUrl(
   project: Project,
   urlString: string
 ): ParseWebSocketConnectRequestUrlResult {
-  if (!urlString.startsWith("/?")) {
+  if (!urlString.startsWith("/elm-watch?")) {
     return {
       tag: "BadUrl",
-      expectedStart: "/?",
+      expectedStart: "/elm-watch?",
       actualUrlString: urlString,
     };
   }
 
   // This never throws as far as I can tell.
-  const params = new URLSearchParams(urlString.slice(2));
+  const params = new URLSearchParams(urlString.slice("/elm-watch?".length));
 
   let webSocketConnectedParams;
   try {

--- a/src/Hot.ts
+++ b/src/Hot.ts
@@ -2153,7 +2153,7 @@ type ParseWebSocketConnectRequestUrlResult =
 type ParseWebSocketConnectRequestUrlError =
   | {
       tag: "BadUrl";
-      expectedStart: "/elm-watch?";
+      expectedStart: typeof WEBSOCKET_URL_EXPECTED_START;
       actualUrlString: string;
     }
   | {
@@ -2179,20 +2179,27 @@ type ParseWebSocketConnectRequestUrlError =
       actualVersion: string;
     };
 
+// We used to require `/?`. Putting “elm-watch” in the path is useful for people
+// running elm-watch behind a proxy: They can use the same port for both the web
+// site and elm-watch, and direct traffic by path matching.
+const WEBSOCKET_URL_EXPECTED_START = "/elm-watch?";
+
 function parseWebSocketConnectRequestUrl(
   project: Project,
   urlString: string
 ): ParseWebSocketConnectRequestUrlResult {
-  if (!urlString.startsWith("/elm-watch?")) {
+  if (!urlString.startsWith(WEBSOCKET_URL_EXPECTED_START)) {
     return {
       tag: "BadUrl",
-      expectedStart: "/elm-watch?",
+      expectedStart: WEBSOCKET_URL_EXPECTED_START,
       actualUrlString: urlString,
     };
   }
 
   // This never throws as far as I can tell.
-  const params = new URLSearchParams(urlString.slice("/elm-watch?".length));
+  const params = new URLSearchParams(
+    urlString.slice(WEBSOCKET_URL_EXPECTED_START.length)
+  );
 
   let webSocketConnectedParams;
   try {

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -618,7 +618,7 @@ describe("hot", () => {
         I ran into an unexpected error! This is the error message:
         I expected the web socket connection URL to start with:
 
-        /?
+        /elm-watch?
 
         But it looks like this:
 
@@ -679,7 +679,7 @@ describe("hot", () => {
 
         The URL looks like this:
 
-        /?elmWatchVersion=%25VERSION%25&targetName=ParamsDecodeError&elmCompiledTimestamp=2021-12-11
+        /elm-watch?elmWatchVersion=%25VERSION%25&targetName=ParamsDecodeError&elmCompiledTimestamp=2021-12-11
 
         The web socket code I generate is supposed to always connect using a correct URL, so something is up here. Maybe the JavaScript code running in the browser was compiled with an older version of elm-watch? If so, try reloading the page.
         ▲ ❌ 13:10:05 ParamsDecodeError
@@ -731,7 +731,7 @@ describe("hot", () => {
 
         The URL looks like this:
 
-        /?elmWatchVersion=%25VERSION%25&targetName=ParamsDecodeError&elmCompiledTimestamp=2021-12-11
+        /elm-watch?elmWatchVersion=%25VERSION%25&targetName=ParamsDecodeError&elmCompiledTimestamp=2021-12-11
 
         The web socket code I generate is supposed to always connect using a correct URL, so something is up here. Maybe the JavaScript code running in the browser was compiled with an older version of elm-watch? If so, try reloading the page.
         ▲ ❌ 13:10:05 ParamsDecodeError


### PR DESCRIPTION
This change the path the `elm-watch` websocket uses from `/` to `/elm-watch`.  This gives the possibility for a proxy to match on the path and route traffic for `elm-watch` to a different port or server.

Resolves #39 

@lydell if you think it's useful I can also update the docs on how to use with a proxy, but no problem if you want to do this yourself.