### PR TITLE
Add Sublime Text example for clickable error locations

### DIFF
--- a/docs/browser-ui.md
+++ b/docs/browser-ui.md
@@ -58,10 +58,11 @@ And here are some commands for a few editors:
 | [VSCode] | `code --goto "$file:$line:$column"` | `code --goto "%file%:%line%:%column%"` |
 | [IntelliJ IDEA] | `idea --line "$line" "$file"` \* | `idea64.exe --line "%line%" "%file%"` † |
 | [Rider] | `rider --line "$line" "$file"` \* | `rider64.exe --line "%line%" "%file%"` † |
+| [Sublime Text] | `subl "$file:$line:$column"` | `subl "%file%:%line%:%column%"` † |
 
 \* Neither IntelliJ IDEA nor Rider come with a command line interface out of the box. Go to `Tools > Create Command-line Launcher…` to activate them. Chances are other [JetBrains] IDEs work similarly, just with different names.
 
-† I haven’t tested IntelliJ IDEA or Rider on Windows, so I’m not 100 % sure about those commands. Let me know if they do or do not work!
+† I haven’t tested IntelliJ IDEA, Rider or Sublime Text on Windows, so I’m not 100 % sure about those commands. Let me know if they do or do not work!
 
 Full examples:
 
@@ -90,3 +91,4 @@ elm-watch executes the `ELM_WATCH_OPEN_EDITOR` environment variable using [child
 [jetbrains]: https://www.jetbrains.com/
 [rider]: https://www.jetbrains.com/rider/
 [vscode]: https://code.visualstudio.com/
+[sublime text]: https://www.sublimetext.com/

--- a/docs/browser-ui.md
+++ b/docs/browser-ui.md
@@ -58,11 +58,13 @@ And here are some commands for a few editors:
 | [VSCode] | `code --goto "$file:$line:$column"` | `code --goto "%file%:%line%:%column%"` |
 | [IntelliJ IDEA] | `idea --line "$line" "$file"` \* | `idea64.exe --line "%line%" "%file%"` † |
 | [Rider] | `rider --line "$line" "$file"` \* | `rider64.exe --line "%line%" "%file%"` † |
-| [Sublime Text] | `subl "$file:$line:$column"` | `subl "%file%:%line%:%column%"` † |
+| [Sublime Text] | `subl "$file:$line:$column"` § | `subl "%file%:%line%:%column%"` § † |
 
 \* Neither IntelliJ IDEA nor Rider come with a command line interface out of the box. Go to `Tools > Create Command-line Launcher…` to activate them. Chances are other [JetBrains] IDEs work similarly, just with different names.
 
 † I haven’t tested IntelliJ IDEA, Rider or Sublime Text on Windows, so I’m not 100 % sure about those commands. Let me know if they do or do not work!
+
+§ For Sublime Text, you might need to [enable the `subl` command][subl].
 
 Full examples:
 
@@ -90,5 +92,6 @@ elm-watch executes the `ELM_WATCH_OPEN_EDITOR` environment variable using [child
 [intellij idea]: https://www.jetbrains.com/idea/
 [jetbrains]: https://www.jetbrains.com/
 [rider]: https://www.jetbrains.com/rider/
+[subl]: https://www.sublimetext.com/docs/command_line.html
 [sublime text]: https://www.sublimetext.com/
 [vscode]: https://code.visualstudio.com/

--- a/docs/browser-ui.md
+++ b/docs/browser-ui.md
@@ -90,5 +90,5 @@ elm-watch executes the `ELM_WATCH_OPEN_EDITOR` environment variable using [child
 [intellij idea]: https://www.jetbrains.com/idea/
 [jetbrains]: https://www.jetbrains.com/
 [rider]: https://www.jetbrains.com/rider/
-[vscode]: https://code.visualstudio.com/
 [sublime text]: https://www.sublimetext.com/
+[vscode]: https://code.visualstudio.com/


### PR DESCRIPTION
Hi! I added a Sublime Text example in the section about clickable error locations. Now using it and it works great! Feel free to accept it or ignore it.

Many many thanks for this tool. Great philosophy and execution. I’m enjoying working with Elm more and more!