### PR TITLE
Document initializing Elm app in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ elm-watch is only responsible for turning your Elm files into JS files. Like run
   <script src="./build/main.js"></script>
   <!-- Launching Elm app. -->
   <script>
-    var app = Elm.Main.init({node: document.getElementById("app")});
+    var app = Elm.Main.init({ node: document.getElementById("app") });
   </script>
   ```
 
@@ -97,7 +97,7 @@ elm-watch is only responsible for turning your Elm files into JS files. Like run
   <script src="/build/main.js"></script>
   <!-- Launching Elm app. -->
   <script>
-    var app = Elm.Main.init({node: document.getElementById("app")});
+    var app = Elm.Main.init({ node: document.getElementById("app") });
   </script>
   ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,16 +75,16 @@ npx elm-watch make --optimize
 
 elm-watch is only responsible for turning your Elm files into JS files. Like running `elm make src/Main.elm --output build/main.js` yourself. So that’s the mindset you need to have.
 
-**You are responsible for** creating an HTML file, link to the built JS and serve files.
+**You are responsible for** creating an HTML file, linking to the built JS, serving files and initializing the app.
 
 - If you’re just getting started, you can create an HTML file with a relative link to the built JS and double-click it to open it in a browser.
 
   ```html
   <!-- Relative URL to the built JS. -->
   <script src="./build/main.js"></script>
-  <!-- Launching Elm app. -->
+  <div id="root"></div>
   <script>
-    var app = Elm.Main.init({ node: document.getElementById("app") });
+    var app = Elm.Main.init({ node: document.getElementById("root") });
   </script>
   ```
 
@@ -95,9 +95,8 @@ elm-watch is only responsible for turning your Elm files into JS files. Like run
   ```html
   <!-- Absolute URL to the built JS. -->
   <script src="/build/main.js"></script>
-  <!-- Launching Elm app. -->
   <script>
-    var app = Elm.Main.init({ node: document.getElementById("app") });
+    var app = Elm.Main.init();
   </script>
   ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,6 +82,10 @@ elm-watch is only responsible for turning your Elm files into JS files. Like run
   ```html
   <!-- Relative URL to the built JS. -->
   <script src="./build/main.js"></script>
+  <!-- Launching Elm app. -->
+  <script>
+    var app = Elm.Main.init({node: document.getElementById("app")});
+  </script>
   ```
 
   👉 [Minimal example](https://github.com/lydell/elm-watch/tree/main/example-minimal#readme)
@@ -91,6 +95,10 @@ elm-watch is only responsible for turning your Elm files into JS files. Like run
   ```html
   <!-- Absolute URL to the built JS. -->
   <script src="/build/main.js"></script>
+  <!-- Launching Elm app. -->
+  <script>
+    var app = Elm.Main.init({node: document.getElementById("app")});
+  </script>
   ```
 
   👉 [Example CLI server tool](https://github.com/vercel/serve)


### PR DESCRIPTION
When trying to make `elm-watch` working for my project, I struggled because I forgot to initialize the elm app. Adding this little snippet would make it really obvious to no have this mistake.