### PR TITLE
Reload the page if a new port is added

### DIFF
--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -248,7 +248,7 @@ var _VirtualDom_init = F4(function(virtualNode, flagDecoder, debugMetadata, args
 		var patches = _VirtualDom_diff(virtualNode, newData.virtualNode);
 		node = _VirtualDom_applyPatches(node, virtualNode, patches, sendToApp);
 		virtualNode = newData.virtualNode;
-		return { tag: "Success" };
+		return [];
 	}
 
 	return Object.defineProperties(

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -74,13 +74,15 @@ function _Platform_initialize(programType, isDebug, debugMetadata, flagDecoder, 
 		_Platform_enqueueEffects(managers, _Platform_batch(_List_Nil), _Platform_batch(_List_Nil));
 		_Scheduler_enqueue = new_Scheduler_enqueue;
 
+		var reloadReasons = [];
+
 		for (var key in new_Platform_effectManagers) {
 			var manager = new_Platform_effectManagers[key];
 			if (!(key in _Platform_effectManagers)) {
 				_Platform_effectManagers[key] = manager;
 				managers[key] = _Platform_instantiateManager(manager, sendToApp);
 				if (manager.a) {
-					console.info("elm-watch: A new port '" + key + "' was added. You might want to reload the page!");
+					reloadReasons.push("a new port '" + key + "' was added. The idea is to give JavaScript code a chance to set it up!");
 					manager.a(key, sendToApp)
 				}
 			}
@@ -98,10 +100,10 @@ function _Platform_initialize(programType, isDebug, debugMetadata, flagDecoder, 
 
 		var newFlagResult = A2(_Json_run, newData.flagDecoder, flags);
 		if (!$elm$core$Result$isOk(newFlagResult)) {
-			return { tag: "ReloadPage", reason: "the flags type in \`" + moduleName + "\` changed and now the passed flags aren't correct anymore. The idea is to try to run with new flags!\\nThis is the error:\\n" + _Json_errorToString(newFlagResult.a) };
+			return reloadReasons.concat("the flags type in \`" + moduleName + "\` changed and now the passed flags aren't correct anymore. The idea is to try to run with new flags!\\nThis is the error:\\n" + _Json_errorToString(newFlagResult.a));
 		}
 		if (!_Utils_eq_elmWatchInternal(debugMetadata, newData.debugMetadata)) {
-			return { tag: "ReloadPage", reason: "the message type in \`" + moduleName + '\` changed in debug mode ("debug metadata" changed).' };
+			return reloadReasons.concat("the message type in \`" + moduleName + '\` changed in debug mode ("debug metadata" changed).');
 		}
 		init = impl.%init% || impl._impl.%init%;
 		if (isDebug) {
@@ -110,13 +112,13 @@ function _Platform_initialize(programType, isDebug, debugMetadata, flagDecoder, 
 		globalThis.__ELM_WATCH.INIT_URL = initUrl;
 		var newInitPair = init(newFlagResult.a);
 		if (!_Utils_eq_elmWatchInternal(initPair, newInitPair)) {
-			return { tag: "ReloadPage", reason: "\`" + moduleName + ".init\` returned something different than last time. Let's start fresh!" };
+			return reloadReasons.concat("\`" + moduleName + ".init\` returned something different than last time. Let's start fresh!");
 		}
 
 		setUpdateAndSubscriptions();
 		stepper(model, true /* isSync */);
 		_Platform_enqueueEffects(managers, _Platform_batch(_List_Nil), subscriptions(model));
-		return { tag: "Success" };
+		return reloadReasons;
 	}
 
 	return Object.defineProperties(
@@ -285,16 +287,9 @@ function _Platform_mergeExportsElmWatch(moduleName, obj, exports)
 						if (app.__elmWatchProgramType !== data.programType) {
 							reloadReasons.push("\`" + moduleName + ".main\` changed from \`" + app.__elmWatchProgramType + "\` to \`" + data.programType + "\`.");
 						} else {
-							var result;
 							try {
-								result = app.__elmWatchHotReload(data, _Platform_effectManagers, _Scheduler_enqueue, moduleName);
-								switch (result.tag) {
-									case "Success":
-										break;
-									case "ReloadPage":
-										reloadReasons.push(result.reason);
-										break;
-								}
+								var innerReasons = app.__elmWatchHotReload(data, _Platform_effectManagers, _Scheduler_enqueue, moduleName);
+								reloadReasons = reloadReasons.concat(innerReasons);
 							} catch (error) {
 								reloadReasons.push("hot reload for \`" + moduleName + "\` failed, probably because of incompatible model changes.\\nThis is the error:\\n" + error + "\\n" + (error ? error.stack : ""));
 							}

--- a/tests/Helpers.ts
+++ b/tests/Helpers.ts
@@ -27,10 +27,6 @@ import {
 } from "../src/Helpers";
 import { IS_WINDOWS } from "../src/IsWindows";
 
-// Workaround for:
-// (node:1847) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Server].
-process.setMaxListeners(20);
-
 toError.jestWorkaround = (arg: unknown): NodeJS.ErrnoException => arg as Error;
 toJsonError.jestWorkaround = (arg: unknown): JsonError => arg as JsonError;
 

--- a/tests/Helpers.ts
+++ b/tests/Helpers.ts
@@ -27,6 +27,10 @@ import {
 } from "../src/Helpers";
 import { IS_WINDOWS } from "../src/IsWindows";
 
+// Workaround for:
+// (node:1847) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Server].
+process.setMaxListeners(20);
+
 toError.jestWorkaround = (arg: unknown): NodeJS.ErrnoException => arg as Error;
 toJsonError.jestWorkaround = (arg: unknown): JsonError => arg as JsonError;
 

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -939,121 +939,118 @@ describe("hot reloading", () => {
     }
   });
 
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // test("Init change cmd", async () => {
-  //   const { replace, lastValueFromElm, go } = runHotReload({
-  //     name: "InitChangeCmd",
-  //     programType: "Element",
-  //     compilationMode: "standard",
-  //   });
+  test("Init change cmd", async () => {
+    const { replace, lastValueFromElm, go } = runHotReload({
+      name: "InitChangeCmd",
+      programType: "Element",
+      compilationMode: "standard",
+    });
 
-  //   const { browserConsole } = await go(({ idle }) => {
-  //     switch (idle) {
-  //       case 1:
-  //         assert1();
-  //         replace((content) =>
-  //           content.replace("module", "port module").replace(/-- /g, "")
-  //         );
-  //         return "KeepGoing";
-  //       default:
-  //         assert2();
-  //         return "Stop";
-  //     }
-  //   });
+    const { browserConsole } = await go(({ idle }) => {
+      switch (idle) {
+        case 1:
+          assert1();
+          replace((content) =>
+            content.replace("module", "port module").replace(/-- /g, "")
+          );
+          return "KeepGoing";
+        default:
+          assert2();
+          return "Stop";
+      }
+    });
 
-  //   expect(browserConsole).toMatchInlineSnapshot(`
-  //     elm-watch: I did a full page reload because:
+    expect(browserConsole).toMatchInlineSnapshot(`
+      elm-watch: I did a full page reload because:
 
-  //     InitChangeCmd
-  //     - a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
-  //     - \`Elm.InitChangeCmd.init\` returned something different than last time. Let's start fresh!
-  //   `);
+      InitChangeCmd
+      - a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
+      - \`Elm.InitChangeCmd.init\` returned something different than last time. Let's start fresh!
+    `);
 
-  //   function assert1(): void {
-  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
-  //   }
+    function assert1(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
+    }
 
-  //   function assert2(): void {
-  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent on init!`);
-  //   }
-  // });
+    function assert2(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent on init!`);
+    }
+  });
 
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // test("Add port used in update", async () => {
-  //   const { replace, lastValueFromElm, go } = runHotReload({
-  //     name: "AddPortUsedInUpdate",
-  //     programType: "Element",
-  //     compilationMode: "standard",
-  //   });
+  test("Add port used in update", async () => {
+    const { replace, lastValueFromElm, go } = runHotReload({
+      name: "AddPortUsedInUpdate",
+      programType: "Element",
+      compilationMode: "standard",
+    });
 
-  //   const { browserConsole } = await go(async ({ idle, main }) => {
-  //     switch (idle) {
-  //       case 1:
-  //         assert1();
-  //         replace((content) =>
-  //           content.replace("module", "port module").replace(/-- /g, "")
-  //         );
-  //         return "KeepGoing";
-  //       default:
-  //         main.click();
-  //         await waitOneFrame();
-  //         assert2();
-  //         return "Stop";
-  //     }
-  //   });
+    const { browserConsole } = await go(async ({ idle, main }) => {
+      switch (idle) {
+        case 1:
+          assert1();
+          replace((content) =>
+            content.replace("module", "port module").replace(/-- /g, "")
+          );
+          return "KeepGoing";
+        default:
+          main.click();
+          await waitOneFrame();
+          assert2();
+          return "Stop";
+      }
+    });
 
-  //   expect(browserConsole).toMatchInlineSnapshot(`
-  //     elm-watch: I did a full page reload because a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
-  //     (target: AddPortUsedInUpdate)
-  //   `);
+    expect(browserConsole).toMatchInlineSnapshot(`
+      elm-watch: I did a full page reload because a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
+      (target: AddPortUsedInUpdate)
+    `);
 
-  //   function assert1(): void {
-  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
-  //   }
+    function assert1(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
+    }
 
-  //   function assert2(): void {
-  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent in update!`);
-  //   }
-  // });
+    function assert2(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent in update!`);
+    }
+  });
 
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // test("Add port used in subscriptions", async () => {
-  //   const { replace, sendToElm, go } = runHotReload({
-  //     name: "AddPortUsedInSubscriptions",
-  //     programType: "Element",
-  //     compilationMode: "standard",
-  //     init: (node) => window.Elm?.AddPortUsedInSubscriptions?.init({ node }),
-  //   });
+  test("Add port used in subscriptions", async () => {
+    const { replace, sendToElm, go } = runHotReload({
+      name: "AddPortUsedInSubscriptions",
+      programType: "Element",
+      compilationMode: "standard",
+      init: (node) => window.Elm?.AddPortUsedInSubscriptions?.init({ node }),
+    });
 
-  //   const { browserConsole } = await go(async ({ idle, main }) => {
-  //     switch (idle) {
-  //       case 1:
-  //         assert1(main);
-  //         replace((content) =>
-  //           content.replace("module", "port module").replace(/-- /g, "")
-  //         );
-  //         return "KeepGoing";
-  //       default:
-  //         sendToElm(1337);
-  //         await waitOneFrame();
-  //         assert2(main);
-  //         return "Stop";
-  //     }
-  //   });
+    const { browserConsole } = await go(async ({ idle, main }) => {
+      switch (idle) {
+        case 1:
+          assert1(main);
+          replace((content) =>
+            content.replace("module", "port module").replace(/-- /g, "")
+          );
+          return "KeepGoing";
+        default:
+          sendToElm(1337);
+          await waitOneFrame();
+          assert2(main);
+          return "Stop";
+      }
+    });
 
-  //   expect(browserConsole).toMatchInlineSnapshot(`
-  //     elm-watch: I did a full page reload because a new port 'fromJs' was added. The idea is to give JavaScript code a chance to set it up!
-  //     (target: AddPortUsedInSubscriptions)
-  //   `);
+    expect(browserConsole).toMatchInlineSnapshot(`
+      elm-watch: I did a full page reload because a new port 'fromJs' was added. The idea is to give JavaScript code a chance to set it up!
+      (target: AddPortUsedInSubscriptions)
+    `);
 
-  //   function assert1(main: HTMLElement): void {
-  //     expect(main.outerHTML).toMatchInlineSnapshot(`<main>0</main>`);
-  //   }
+    function assert1(main: HTMLElement): void {
+      expect(main.outerHTML).toMatchInlineSnapshot(`<main>0</main>`);
+    }
 
-  //   function assert2(main: HTMLElement): void {
-  //     expect(main.outerHTML).toMatchInlineSnapshot(`<main>1337</main>`);
-  //   }
-  // });
+    function assert2(main: HTMLElement): void {
+      expect(main.outerHTML).toMatchInlineSnapshot(`<main>1337</main>`);
+    }
+  });
 
   test("Change program type", async () => {
     const { write, go } = runHotReload({

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -937,61 +937,42 @@ describe("hot reloading", () => {
     }
   });
 
-  describe("Init change cmd", () => {
-    // eslint-disable-next-line no-console
-    const originalConsoleInfo = console.info;
-
-    afterEach(() => {
-      // eslint-disable-next-line no-console
-      console.info = originalConsoleInfo;
+  test("Init change cmd", async () => {
+    const { replace, lastValueFromElm, go } = runHotReload({
+      name: "InitChangeCmd",
+      programType: "Element",
+      compilationMode: "standard",
     });
 
-    test("Init change cmd", async () => {
-      const mockConsoleInfo = jest.fn();
-      // eslint-disable-next-line no-console
-      console.info = mockConsoleInfo;
-
-      const { replace, lastValueFromElm, go } = runHotReload({
-        name: "InitChangeCmd",
-        programType: "Element",
-        compilationMode: "standard",
-      });
-
-      const { browserConsole } = await go(({ idle }) => {
-        switch (idle) {
-          case 1:
-            assert1();
-            replace((content) =>
-              content.replace("module", "port module").replace(/-- /g, "")
-            );
-            return "KeepGoing";
-          default:
-            assert2();
-            return "Stop";
-        }
-      });
-
-      expect(browserConsole).toMatchInlineSnapshot(`
-          elm-watch: I did a full page reload because \`Elm.InitChangeCmd.init\` returned something different than last time. Let's start fresh!
-          (target: InitChangeCmd)
-        `);
-
-      expect(mockConsoleInfo.mock.calls).toMatchInlineSnapshot(`
-          [
-            [
-              elm-watch: A new port 'toJs' was added. You might want to reload the page!,
-            ],
-          ]
-        `);
-
-      function assert1(): void {
-        expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
-      }
-
-      function assert2(): void {
-        expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent on init!`);
+    const { browserConsole } = await go(({ idle }) => {
+      switch (idle) {
+        case 1:
+          assert1();
+          replace((content) =>
+            content.replace("module", "port module").replace(/-- /g, "")
+          );
+          return "KeepGoing";
+        default:
+          assert2();
+          return "Stop";
       }
     });
+
+    expect(browserConsole).toMatchInlineSnapshot(`
+      elm-watch: I did a full page reload because:
+
+      InitChangeCmd
+      - a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
+      - \`Elm.InitChangeCmd.init\` returned something different than last time. Let's start fresh!
+    `);
+
+    function assert1(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
+    }
+
+    function assert2(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent on init!`);
+    }
   });
 
   test("Change program type", async () => {

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -939,7 +939,7 @@ describe("hot reloading", () => {
     }
   });
 
-  test("Init change cmd", async () => {
+  test("Init change cmd / Add port used in init", async () => {
     const { replace, lastValueFromElm, go } = runHotReload({
       name: "InitChangeCmd",
       programType: "Element",

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -975,6 +975,43 @@ describe("hot reloading", () => {
     }
   });
 
+  test("Add port used in update", async () => {
+    const { replace, lastValueFromElm, go } = runHotReload({
+      name: "AddPortUsedInUpdate",
+      programType: "Element",
+      compilationMode: "standard",
+    });
+
+    const { browserConsole } = await go(async ({ idle, main }) => {
+      switch (idle) {
+        case 1:
+          assert1();
+          replace((content) =>
+            content.replace("module", "port module").replace(/-- /g, "")
+          );
+          return "KeepGoing";
+        default:
+          main.click();
+          await waitOneFrame();
+          assert2();
+          return "Stop";
+      }
+    });
+
+    expect(browserConsole).toMatchInlineSnapshot(`
+      elm-watch: I did a full page reload because a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
+      (target: AddPortUsedInUpdate)
+    `);
+
+    function assert1(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
+    }
+
+    function assert2(): void {
+      expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent in update!`);
+    }
+  });
+
   test("Change program type", async () => {
     const { write, go } = runHotReload({
       name: "ChangeProgramType",

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -939,118 +939,121 @@ describe("hot reloading", () => {
     }
   });
 
-  test("Init change cmd", async () => {
-    const { replace, lastValueFromElm, go } = runHotReload({
-      name: "InitChangeCmd",
-      programType: "Element",
-      compilationMode: "standard",
-    });
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // test("Init change cmd", async () => {
+  //   const { replace, lastValueFromElm, go } = runHotReload({
+  //     name: "InitChangeCmd",
+  //     programType: "Element",
+  //     compilationMode: "standard",
+  //   });
 
-    const { browserConsole } = await go(({ idle }) => {
-      switch (idle) {
-        case 1:
-          assert1();
-          replace((content) =>
-            content.replace("module", "port module").replace(/-- /g, "")
-          );
-          return "KeepGoing";
-        default:
-          assert2();
-          return "Stop";
-      }
-    });
+  //   const { browserConsole } = await go(({ idle }) => {
+  //     switch (idle) {
+  //       case 1:
+  //         assert1();
+  //         replace((content) =>
+  //           content.replace("module", "port module").replace(/-- /g, "")
+  //         );
+  //         return "KeepGoing";
+  //       default:
+  //         assert2();
+  //         return "Stop";
+  //     }
+  //   });
 
-    expect(browserConsole).toMatchInlineSnapshot(`
-      elm-watch: I did a full page reload because:
+  //   expect(browserConsole).toMatchInlineSnapshot(`
+  //     elm-watch: I did a full page reload because:
 
-      InitChangeCmd
-      - a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
-      - \`Elm.InitChangeCmd.init\` returned something different than last time. Let's start fresh!
-    `);
+  //     InitChangeCmd
+  //     - a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
+  //     - \`Elm.InitChangeCmd.init\` returned something different than last time. Let's start fresh!
+  //   `);
 
-    function assert1(): void {
-      expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
-    }
+  //   function assert1(): void {
+  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
+  //   }
 
-    function assert2(): void {
-      expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent on init!`);
-    }
-  });
+  //   function assert2(): void {
+  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent on init!`);
+  //   }
+  // });
 
-  test("Add port used in update", async () => {
-    const { replace, lastValueFromElm, go } = runHotReload({
-      name: "AddPortUsedInUpdate",
-      programType: "Element",
-      compilationMode: "standard",
-    });
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // test("Add port used in update", async () => {
+  //   const { replace, lastValueFromElm, go } = runHotReload({
+  //     name: "AddPortUsedInUpdate",
+  //     programType: "Element",
+  //     compilationMode: "standard",
+  //   });
 
-    const { browserConsole } = await go(async ({ idle, main }) => {
-      switch (idle) {
-        case 1:
-          assert1();
-          replace((content) =>
-            content.replace("module", "port module").replace(/-- /g, "")
-          );
-          return "KeepGoing";
-        default:
-          main.click();
-          await waitOneFrame();
-          assert2();
-          return "Stop";
-      }
-    });
+  //   const { browserConsole } = await go(async ({ idle, main }) => {
+  //     switch (idle) {
+  //       case 1:
+  //         assert1();
+  //         replace((content) =>
+  //           content.replace("module", "port module").replace(/-- /g, "")
+  //         );
+  //         return "KeepGoing";
+  //       default:
+  //         main.click();
+  //         await waitOneFrame();
+  //         assert2();
+  //         return "Stop";
+  //     }
+  //   });
 
-    expect(browserConsole).toMatchInlineSnapshot(`
-      elm-watch: I did a full page reload because a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
-      (target: AddPortUsedInUpdate)
-    `);
+  //   expect(browserConsole).toMatchInlineSnapshot(`
+  //     elm-watch: I did a full page reload because a new port 'toJs' was added. The idea is to give JavaScript code a chance to set it up!
+  //     (target: AddPortUsedInUpdate)
+  //   `);
 
-    function assert1(): void {
-      expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
-    }
+  //   function assert1(): void {
+  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`undefined`);
+  //   }
 
-    function assert2(): void {
-      expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent in update!`);
-    }
-  });
+  //   function assert2(): void {
+  //     expect(lastValueFromElm.value).toMatchInlineSnapshot(`sent in update!`);
+  //   }
+  // });
 
-  test("Add port used in subscriptions", async () => {
-    const { replace, sendToElm, go } = runHotReload({
-      name: "AddPortUsedInSubscriptions",
-      programType: "Element",
-      compilationMode: "standard",
-      init: (node) => window.Elm?.AddPortUsedInSubscriptions?.init({ node }),
-    });
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // test("Add port used in subscriptions", async () => {
+  //   const { replace, sendToElm, go } = runHotReload({
+  //     name: "AddPortUsedInSubscriptions",
+  //     programType: "Element",
+  //     compilationMode: "standard",
+  //     init: (node) => window.Elm?.AddPortUsedInSubscriptions?.init({ node }),
+  //   });
 
-    const { browserConsole } = await go(async ({ idle, main }) => {
-      switch (idle) {
-        case 1:
-          assert1(main);
-          replace((content) =>
-            content.replace("module", "port module").replace(/-- /g, "")
-          );
-          return "KeepGoing";
-        default:
-          sendToElm(1337);
-          await waitOneFrame();
-          assert2(main);
-          return "Stop";
-      }
-    });
+  //   const { browserConsole } = await go(async ({ idle, main }) => {
+  //     switch (idle) {
+  //       case 1:
+  //         assert1(main);
+  //         replace((content) =>
+  //           content.replace("module", "port module").replace(/-- /g, "")
+  //         );
+  //         return "KeepGoing";
+  //       default:
+  //         sendToElm(1337);
+  //         await waitOneFrame();
+  //         assert2(main);
+  //         return "Stop";
+  //     }
+  //   });
 
-    expect(browserConsole).toMatchInlineSnapshot(`
-      elm-watch: I did a full page reload because a new port 'fromJs' was added. The idea is to give JavaScript code a chance to set it up!
-      (target: AddPortUsedInSubscriptions)
-    `);
+  //   expect(browserConsole).toMatchInlineSnapshot(`
+  //     elm-watch: I did a full page reload because a new port 'fromJs' was added. The idea is to give JavaScript code a chance to set it up!
+  //     (target: AddPortUsedInSubscriptions)
+  //   `);
 
-    function assert1(main: HTMLElement): void {
-      expect(main.outerHTML).toMatchInlineSnapshot(`<main>0</main>`);
-    }
+  //   function assert1(main: HTMLElement): void {
+  //     expect(main.outerHTML).toMatchInlineSnapshot(`<main>0</main>`);
+  //   }
 
-    function assert2(main: HTMLElement): void {
-      expect(main.outerHTML).toMatchInlineSnapshot(`<main>1337</main>`);
-    }
-  });
+  //   function assert2(main: HTMLElement): void {
+  //     expect(main.outerHTML).toMatchInlineSnapshot(`<main>1337</main>`);
+  //   }
+  // });
 
   test("Change program type", async () => {
     const { write, go } = runHotReload({

--- a/tests/fixtures/hot/hot-reload/elm-watch.json
+++ b/tests/fixtures/hot/hot-reload/elm-watch.json
@@ -72,6 +72,12 @@
             ],
             "output": "build/AddPortUsedInUpdate.js"
         },
+        "AddPortUsedInSubscriptions": {
+            "inputs": [
+                "src/AddPortUsedInSubscriptions.elm"
+            ],
+            "output": "build/AddPortUsedInSubscriptions.js"
+        },
         "ChangeProgramType": {
             "inputs": [
                 "src/ChangeProgramType.elm"

--- a/tests/fixtures/hot/hot-reload/elm-watch.json
+++ b/tests/fixtures/hot/hot-reload/elm-watch.json
@@ -66,6 +66,12 @@
             ],
             "output": "build/InitChangeCmd.js"
         },
+        "AddPortUsedInUpdate": {
+            "inputs": [
+                "src/AddPortUsedInUpdate.elm"
+            ],
+            "output": "build/AddPortUsedInUpdate.js"
+        },
         "ChangeProgramType": {
             "inputs": [
                 "src/ChangeProgramType.elm"

--- a/tests/fixtures/hot/hot-reload/src/AddPortUsedInSubscriptions1.elm
+++ b/tests/fixtures/hot/hot-reload/src/AddPortUsedInSubscriptions1.elm
@@ -1,0 +1,53 @@
+module AddPortUsedInSubscriptions1 exposing (main)
+
+import Browser
+import Html exposing (Html)
+import Html.Events
+
+
+
+-- port fromJs : (Int -> msg) -> Sub msg
+
+
+type alias Model =
+    Int
+
+
+type Msg
+    = FromJs Int
+
+
+init : () -> ( Model, Cmd Msg )
+init () =
+    ( 0, Cmd.none )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg _ =
+    case msg of
+        FromJs int ->
+            ( int, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.batch
+        [ Sub.none
+
+        -- , fromJs FromJs
+        ]
+
+
+view : Model -> Html Msg
+view model =
+    Html.main_ [] [ Html.text (String.fromInt model) ]
+
+
+main : Program () Model Msg
+main =
+    Browser.element
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }

--- a/tests/fixtures/hot/hot-reload/src/AddPortUsedInUpdate1.elm
+++ b/tests/fixtures/hot/hot-reload/src/AddPortUsedInUpdate1.elm
@@ -1,0 +1,43 @@
+module AddPortUsedInUpdate1 exposing (main)
+
+import Browser
+import Html exposing (Html)
+import Html.Events
+
+
+
+-- port toJs : String -> Cmd msg
+
+
+init : () -> ( (), Cmd () )
+init () =
+    ( (), Cmd.none )
+
+
+update : () -> () -> ( (), Cmd () )
+update () model =
+    ( model
+    , Cmd.batch
+        [ Cmd.none
+
+        -- , toJs "sent in update!"
+        ]
+    )
+
+
+view : () -> Html ()
+view () =
+    Html.main_
+        [-- Html.Events.onClick ()
+        ]
+        [ Html.text "main" ]
+
+
+main : Program () () ()
+main =
+    Browser.element
+        { init = init
+        , update = update
+        , subscriptions = always Sub.none
+        , view = view
+        }

--- a/tests/fixtures/hot/hot-reload/src/AllProgramTypes/ApplicationProgram.elm
+++ b/tests/fixtures/hot/hot-reload/src/AllProgramTypes/ApplicationProgram.elm
@@ -1,8 +1,8 @@
 module AllProgramTypes.ApplicationProgram exposing (main)
 
+import AllProgramTypes
 import Browser
 import Html
-import AllProgramTypes
 
 
 main =

--- a/tests/fixtures/hot/hot-reload/src/AllProgramTypes/ElementProgram.elm
+++ b/tests/fixtures/hot/hot-reload/src/AllProgramTypes/ElementProgram.elm
@@ -1,8 +1,8 @@
 module AllProgramTypes.ElementProgram exposing (main)
 
+import AllProgramTypes
 import Browser
 import Html
-import AllProgramTypes
 
 
 main =

--- a/tests/fixtures/hot/hot-reload/src/AllProgramTypes/HtmlProgram.elm
+++ b/tests/fixtures/hot/hot-reload/src/AllProgramTypes/HtmlProgram.elm
@@ -1,7 +1,7 @@
 module AllProgramTypes.HtmlProgram exposing (main)
 
-import Html
 import AllProgramTypes
+import Html
 
 
 main =

--- a/tests/fixtures/hot/hot-reload/src/AllProgramTypes/SandboxProgram.elm
+++ b/tests/fixtures/hot/hot-reload/src/AllProgramTypes/SandboxProgram.elm
@@ -1,8 +1,8 @@
 module AllProgramTypes.SandboxProgram exposing (main)
 
+import AllProgramTypes
 import Browser
 import Html
-import AllProgramTypes
 
 
 main =

--- a/tests/fixtures/hot/hot-reload/src/InitChangeCmd1.elm
+++ b/tests/fixtures/hot/hot-reload/src/InitChangeCmd1.elm
@@ -8,13 +8,9 @@ import Html exposing (Html)
 -- port toJs : String -> Cmd msg
 
 
-type alias Model =
-    String
-
-
-init : () -> ( Model, Cmd () )
+init : () -> ( (), Cmd () )
 init () =
-    ( "init"
+    ( ()
     , Cmd.batch
         [ Cmd.none
 
@@ -23,11 +19,11 @@ init () =
     )
 
 
-main : Program () Model ()
+main : Program () () ()
 main =
     Browser.element
         { init = init
-        , update = \() model -> ( model, Cmd.none )
-        , subscriptions = always Sub.none
-        , view = Html.text
+        , update = \() () -> ( (), Cmd.none )
+        , subscriptions = \() -> Sub.none
+        , view = \() -> Html.text ""
         }


### PR DESCRIPTION
Previously, elm-watch only `console.info`:ed a message in this case.

Here’s a use case for reloading:

1. Start elm-watch, but don’t open any tabs in the browser, so no target is connected via WebSocket to elm-watch.
2. Add a new port in Elm.
3. Use that port in JavaScript.
4. Go to the app in the browser.

State: The JavaScript is ready for the new port already, but the compiled JS for Elm is old.

What happens: elm-watch starts compiling for real since the target connected via WebSocket, and sends over the new JS. We detect the new port and reload the page. The JavaScript code now gets to set that port up for real.