### PR TITLE
Fix typo

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -128,7 +128,7 @@ Note that `index.html` files must be called exactly `index.html`. Not `index.htm
 
 What would happen if you named `public/admin/index.html` just `public/admin.html` instead? There’s nothing stopping you from doing it. You would need to go to `/admin.html` to access it. Which would probably render a 404-style page in your `Browser.application` program, since you most likely have no route matching `/admin.html`. And if the `Browser.application` program ever changes the URL, refreshing the page won’t work. So stick to `index.html` files for `Browser.application` programs.
 
-I recommend always creating a `index.html` directly in your static files directory. elm-watch prints a link to the static file server on start up, and if you have a root `index.html` file, that link will take you somewhere useful from the get go.
+I recommend always creating an `index.html` directly in your static files directory. elm-watch prints a link to the static file server on start up, and if you have a root `index.html` file, that link will take you somewhere useful from the get go.
 
 ## Browser.application
 


### PR DESCRIPTION
"a `index.html`" → "an `index.html`"