### PR TITLE
Make elm-watch independent of window.Elm

### DIFF
--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -38,9 +38,6 @@ const elmProxy = new Proxy(existingObject ?? {}, {
     throw error;
   },
   has(target, property) {
-    if (property === "__elmWatchProxy") {
-      return true;
-    }
     const has = Reflect.has(target, property);
     if (has) {
       return true;
@@ -53,5 +50,7 @@ const elmProxy = new Proxy(existingObject ?? {}, {
 });
 
 window.Elm = elmProxy;
+
+window.__ELM_WATCH.REGISTER?.({});
 
 export {};

--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -51,6 +51,6 @@ const elmProxy = new Proxy(existingObject ?? {}, {
 
 window.Elm = elmProxy;
 
-window.__ELM_WATCH.REGISTER?.({});
+window.__ELM_WATCH.REGISTER("%TARGET_NAME%", {});
 
 export {};

--- a/docs/window.Elm.md
+++ b/docs/window.Elm.md
@@ -7,7 +7,8 @@ nav_order: 12
 
 elm-watch is basically just `elm make` in watch mode, so the output format is using the good old `window.Elm` global.
 
-elm-watch even _requires `window.Elm` to exist._ That global variable is key to make [hot reloading](../hot-reloading/) work. (Technically, `globalThis.Elm` is required to exist. See below.)
+{: .info }  
+ℹ️ elm-watch 1.1.3 even _required `window.Elm` to exist,_ to make [hot reloading](../hot-reloading/) work. Newer versions of elm-watch don’t mind if you change that, though.
 
 **In short:** Keep it simple and load the built Elm JS in its own `<script>` tag and you’ll be fine.
 
@@ -21,7 +22,7 @@ const root = document.getElementById("root");
 +const app = window.Elm.Main.init({ node: root });
 ```
 
-Regardless of whether you use a bundler or just standard `import`s, **don’t** be tempted to `import` the built Elm JS:
+Regardless of whether you use a bundler or just standard `import`s, **don’t** be tempted to `import` the built Elm JS. elm-watch compiles Elm just like `elm make`, and neither support `import` out of the box:
 
 ```js
 // 🚨 WRONG! Don’t do this!
@@ -66,6 +67,20 @@ Having `window.Elm.Main.init()` in your code might feel ugly and old-school comp
 - It makes hot reloading work without any setup.
 - And it can even be good for browser caching! Your Elm code might change very often, but some JavaScript code (perhaps using an npm package) might be very stable and can then be cached independently from the compiled Elm code.
 
+If you _really_ want to `import` your Elm code, you can postprocess the code into an actual ECMAScript module:
+
+```js
+function postprocess({ code }) {
+  return `const output = {}; (function(){${code}}).call(output); export default output.Elm;`;
+}
+```
+
+{: .warning }  
+⚠️ Beware that if you put a script tag on your page that loads a JS file, which in turns `import`s the compiled Elm code, it might cause your page to load more slowly, since the compiled Elm code needs to wait for the first JS file to download and execute first.
+
+Note that [elm-esm] does not work with elm-watch: It replaces a bit too much of the code.
+
+[elm-esm]: https://github.com/ChristophP/elm-esm
 [globalthis]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
 [parcel]: https://parceljs.org/
 [platform.worker]: https://package.elm-lang.org/packages/elm/core/latest/Platform#worker

--- a/example/elm-watch.json
+++ b/example/elm-watch.json
@@ -51,6 +51,12 @@
             ],
             "output": "public/build/Frankenstein.js"
         },
+        "ESM": {
+            "inputs": [
+                "src/HtmlMain.elm"
+            ],
+            "output": "public/build/ESM.js"
+        },
         "🇫🇷 Azimutt": {
             "inputs": [
                 "public/submodules/azimutt/.elm-spa/defaults/Main.elm"

--- a/example/elm-watch.json
+++ b/example/elm-watch.json
@@ -40,6 +40,12 @@
             ],
             "output": "public/build/WorkerMain.js"
         },
+        "WorkerESM": {
+            "inputs": [
+                "src/WorkerMain.elm"
+            ],
+            "output": "public/build/WorkerMainESM.js"
+        },
         "Frankenstein": {
             "inputs": [
                 "src/ApplicationMain.elm",

--- a/example/postprocess.js
+++ b/example/postprocess.js
@@ -30,12 +30,11 @@ export default async function postprocess({
  * @returns {string}
  */
 function patch(targetName, code) {
-  switch (targetName) {
-    case "ESM":
-      // Turn the Elm JS into an ECMAScript module:
-      return `const output = {}; (function(){${code}}).call(output); export default output.Elm;`;
-    default:
-      return code;
+  if (targetName.includes("ESM")) {
+    // Turn the Elm JS into an ECMAScript module:
+    return `const output = {}; (function(){${code}}).call(output); export default output.Elm;`;
+  } else {
+    return code;
   }
 }
 

--- a/example/postprocess.js
+++ b/example/postprocess.js
@@ -12,15 +12,30 @@ export default async function postprocess({
   switch (compilationMode) {
     case "standard":
     case "debug":
-      return code;
+      return patch(targetName, code);
 
     case "optimize":
-      return minify(code);
+      return minify(patch(targetName, code));
 
     default:
       throw new Error(
         `Unknown compilation mode: ${JSON.stringify(compilationMode)}`,
       );
+  }
+}
+
+/**
+ * @param {string} targetName
+ * @param {string} code
+ * @returns {string}
+ */
+function patch(targetName, code) {
+  switch (targetName) {
+    case "ESM":
+      // Turn the Elm JS into an ECMAScript module:
+      return `const output = {}; (function(){${code}}).call(output); export default output.Elm;`;
+    default:
+      return code;
   }
 }
 
@@ -43,7 +58,12 @@ const pureFuncs = [
   "A9",
 ];
 
-// Source: https://discourse.elm-lang.org/t/elm-minification-benchmarks/9968
+/**
+ * Source: https://discourse.elm-lang.org/t/elm-minification-benchmarks/9968
+ *
+ * @param {string} code
+ * @returns {Promise<string>}
+ */
 async function minify(code) {
   return (
     await swc.minify(code, {

--- a/example/public/ESM.html
+++ b/example/public/ESM.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ESM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module">
+      import * as Elm from "/build/ESM.js";
+      Elm.default.HtmlMain.init({ node: document.getElementById("root") });
+    </script>
+  </body>
+</html>

--- a/example/public/WebWorkerMainESM.html
+++ b/example/public/WebWorkerMainESM.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebWorkerMainESM</title>
+  </head>
+  <body>
+    <p>
+      <input type="text" id="input" />
+      <button type="button" id="send">Send message</button>
+    </p>
+    <p>
+      Last sent message has this many duplicates: <span id="duplicates">0</span>
+    </p>
+    <script>
+      const worker = new Worker("workerESM.js", { type: "module" });
+
+      worker.addEventListener("message", (event) => {
+        duplicates.textContent = event.data;
+      });
+
+      send.onclick = () => {
+        worker.postMessage(input.value);
+        input.value = "";
+      };
+    </script>
+  </body>
+</html>

--- a/example/public/workerESM.js
+++ b/example/public/workerESM.js
@@ -1,0 +1,11 @@
+import Elm from "/build/WorkerMainESM.js";
+
+const app = Elm.WorkerMain.init();
+
+self.addEventListener("message", (event) => {
+  app.ports.fromJs.send(event.data);
+});
+
+app.ports.toJs.subscribe((numDuplicates) => {
+  self.postMessage(numDuplicates);
+});

--- a/scripts/BenchmarkInject.ts
+++ b/scripts/BenchmarkInject.ts
@@ -10,6 +10,7 @@ import {
   Cwd,
   markAsAbsolutePath,
   markAsCwd,
+  markAsTargetName,
 } from "../src/Types";
 
 class KnownError extends Error {}
@@ -35,7 +36,7 @@ function run(args: Array<string>): void {
   const code = fs.readFileSync(elmFile, "utf8");
 
   console.time("Run");
-  const newCode = inject(compilationMode, code);
+  const newCode = inject(compilationMode, code, markAsTargetName("TargetName"));
   console.timeEnd("Run");
 
   const oldLines = code.split("\n").length;

--- a/src/Compile.ts
+++ b/src/Compile.ts
@@ -911,7 +911,11 @@ function onCompileSuccess(
         outputState.compilationMode,
         code,
       );
-      const newCode = Inject.inject(outputState.compilationMode, code);
+      const newCode = Inject.inject(
+        outputState.compilationMode,
+        code,
+        outputPath.targetName,
+      );
 
       outputStatus.injectDurationMs = getNow().getTime() - elmCompiledTimestamp;
 

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -132,29 +132,3 @@ export function unknownErrorToString(error: unknown): string {
       ? (error as { message: string }).message
       : Codec.repr(error);
 }
-
-// This function is covered by the "Unexpected/unhandled error at eval" test,
-// but for some reason it is reported as not covered, so we have to ignore it.
-/* v8 ignore start */
-export function codecCatcher<Decoded, Encoded>(
-  codec: Codec.Codec<Decoded, Encoded>,
-): Codec.Codec<Decoded, Encoded> {
-  return {
-    decoder: (value) => {
-      try {
-        return codec.decoder(value);
-      } catch (error) {
-        return {
-          tag: "DecoderError",
-          error: {
-            tag: "custom",
-            message: error instanceof Error ? error.message : String(error),
-            path: [],
-          },
-        };
-      }
-    },
-    encoder: codec.encoder,
-  };
-}
-/* v8 ignore stop */

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -838,7 +838,7 @@ export function proxyFile(
   // are `default` and `Elm`, so make those available. To not break
   // regular scripts (non-ESM), where `export` is a syntax error,
   // use this cursed polyglot syntax: https://stackoverflow.com/a/72314371
-  return `${clientCodeString}\n${proxyCodeString}\n0 && await/2//2; const Elm = window.Elm; export { Elm as default, Elm as Elm }`;
+  return `${clientCodeString}\n${proxyCodeString}\n0 && await/2//2; const Elm = globalThis.Elm; export { Elm as default, Elm as Elm }`;
 }
 
 export function clientCode(

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -708,6 +708,7 @@ export function inject(
       // Doing this as a separate replacement is faster than trying to add it to `REPLACEMENT_REGEX`.
       .replace(
         /^\t\tvar elmWatchTargetName = "";$/m,
+        /* v8 ignore next */
         `\t\tvar elmWatchTargetName = ${Codec.JSON.stringify(Codec.string, targetName ?? "")};`,
       )
   );

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -833,7 +833,12 @@ export function proxyFile(
     /"%TARGET_NAME%"/g,
     Codec.JSON.stringify(Codec.string, outputPath.targetName),
   );
-  return `${clientCodeString}\n${proxyCodeString}`;
+  // In ESM, importing something that isn’t exported is an error.
+  // When ESM-ify:ing Elm’s output, the two most likely export names
+  // are `default` and `Elm`, so make those available. To not break
+  // regular scripts (non-ESM), where `export` is a syntax error,
+  // use this cursed polyglot syntax: https://stackoverflow.com/a/72314371
+  return `${clientCodeString}\n${proxyCodeString}\n0 && await/2//2; const Elm = window.Elm; export { Elm as default, Elm as Elm }`;
 }
 
 export function clientCode(

--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -273,6 +273,7 @@ function _Platform_export(exports)
 {
 	// added by elm-watch
 	if (globalThis.__ELM_WATCH) {
+		var elmWatchTargetName = "";
 		if (globalThis.__ELM_WATCH.REGISTER) {
 			globalThis.__ELM_WATCH.REGISTER(exports);
 		} else {
@@ -690,14 +691,19 @@ const REPLACEMENTS_WITHOUT_PLACEHOLDERS = updateReplacements({}, REPLACEMENTS);
 export function inject(compilationMode: CompilationMode, code: string): string {
   const replacements = getReplacements(compilationMode, code);
 
-  return code.replace(
-    REPLACEMENT_REGEX,
-    (match, name1: string, name: string = name1) =>
-      /* v8 ignore start */
-      replacements[name] ??
-      `${match} /* elm-watch ERROR: No replacement for function '${name}' was found! */`,
-    /* v8 ignore stop */
-  );
+  return code
+    .replace(
+      REPLACEMENT_REGEX,
+      (match, name1: string, name: string = name1) =>
+        /* v8 ignore start */
+        replacements[name] ??
+        `${match} /* elm-watch ERROR: No replacement for function '${name}' was found! */`,
+      /* v8 ignore stop */
+    )
+    .replace(
+      /^\t\tvar elmWatchTargetName = "";$/,
+      `\t\tvar elmWatchTargetName = "";`,
+    );
 }
 
 function getReplacements(

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -2,7 +2,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as Codec from "tiny-decoders";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, onTestFinished, test } from "vitest";
 
 import { WebSocketToServerMessage } from "../client/WebSocketMessages";
 import {
@@ -3245,14 +3245,21 @@ describe("hot", () => {
     }
   });
 
-  // Remove? Or change this into testing that a bundler has rewritten the scope?
-  test.skip("missing window.Elm", async () => {
-    const { onlyExpandedRenders } = await run({
+  test("missing window.Elm", async () => {
+    (window as unknown as { NotElm: unknown }).NotElm = {};
+    onTestFinished(() => {
+      delete (window as unknown as { NotElm: unknown }).NotElm;
+    });
+
+    const { onlyExpandedRenders, div } = await run({
       fixture: "missing-window-elm",
       args: ["Main"],
       scripts: ["Main.js"],
-      init: () => {
+      init: (node) => {
         expect(window.Elm).toBeUndefined();
+        (window as unknown as { NotElm: typeof window }).NotElm.Elm?.[
+          "Main"
+        ]?.init({ node });
       },
       onIdle: () => {
         expandUi();
@@ -3266,11 +3273,16 @@ describe("hot", () => {
       web socket ws://localhost:59123
       updated 2022-02-05 13:10:05
       status Successfully compiled
-      elm-watch requires [window.Elm](https://lydell.github.io/elm-watch/window.Elm/) to exist, but it is undefined!
+      Compilation mode
+      ◯ (disabled) Debug The Elm debugger isn't supported by \`Html\` programs.
+      ◉ Standard
+      ◯ Optimize
       ↑↗
       ·→
-      ▲ ❌ 13:10:05 Main
+      ▲ ✅ 13:10:05 Main
     `);
+
+    expect(div.outerHTML).toMatchInlineSnapshot(`<div>Main</div>`);
   });
 
   test("Move UI", async () => {

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -94,7 +94,7 @@ describe("hot", () => {
     expect(div.outerHTML).toMatchInlineSnapshot(`<div>Hello, World!</div>`);
   });
 
-  test.only("successful connect (expanded, not TTY, Worker)", async () => {
+  test("successful connect (expanded, not TTY, Worker)", async () => {
     const { terminal, renders } = await run({
       fixture: "basic",
       args: ["Worker"],

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -94,7 +94,7 @@ describe("hot", () => {
     expect(div.outerHTML).toMatchInlineSnapshot(`<div>Hello, World!</div>`);
   });
 
-  test("successful connect (expanded, not TTY, Worker)", async () => {
+  test.only("successful connect (expanded, not TTY, Worker)", async () => {
     const { terminal, renders } = await run({
       fixture: "basic",
       args: ["Worker"],

--- a/tests/Hot.test.ts
+++ b/tests/Hot.test.ts
@@ -3245,7 +3245,8 @@ describe("hot", () => {
     }
   });
 
-  test("missing window.Elm", async () => {
+  // Remove? Or change this into testing that a bundler has rewritten the scope?
+  test.skip("missing window.Elm", async () => {
     const { onlyExpandedRenders } = await run({
       fixture: "missing-window-elm",
       args: ["Main"],

--- a/tests/HotHelpers.ts
+++ b/tests/HotHelpers.ts
@@ -244,6 +244,17 @@ export async function run({
         .catch(reject);
     };
 
+    // JSDOM does not support `URL.createObjectURL`, so we use the approach
+    // that we used to do in elm-watch instead. Note that this does not support
+    // `import` and `export`.
+    // eslint-disable-next-line @typescript-eslint/require-await
+    window.__ELM_WATCH.EVAL_AS_MODULE = async (code) => {
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const f = new Function(code);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      f();
+    };
+
     window.__ELM_WATCH.ON_RENDER = (targetName) => {
       withShadowRoot((shadowRoot) => {
         const element = shadowRoot.lastElementChild;

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -1424,8 +1424,7 @@ describe("hot reloading", () => {
     }
   });
 
-  // TODO: Remove? Have to change it for code coverage?
-  test.skip("Unexpected/unhandled error at eval", async () => {
+  test("Unexpected/unhandled error at eval", async () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalPromiseReject = Promise.reject;
 
@@ -1450,139 +1449,27 @@ describe("hot reloading", () => {
       name: "HtmlMain",
       programType: "Html",
       compilationMode: "standard",
-      expandUiImmediately: true,
     });
 
-    const { renders } = await go(({ idle, div }) => {
+    const { onlyExpandedRenders } = await go(({ idle, div }) => {
       switch (idle) {
         case 1:
           assert1(div);
-          Object.defineProperty(window.Elm?.["HtmlMain"], "__elmWatchApps", {
-            get() {
-              throw error;
-            },
-          });
+          window.__ELM_WATCH.HOT_RELOAD = () => {
+            throw error;
+          };
           replace((content) =>
             content.replace("hot reload", "simple text change"),
           );
           return "KeepGoing";
         default:
           assert2(div);
+          expandUi();
           return "Stop";
       }
     });
 
-    expect(renders).toMatchInlineSnapshot(`
-      ▼ 🔌 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Connecting
-      attempt 1
-      sleep 1.01 seconds
-      [Connecting web socket…]
-      ▲ 🔌 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Waiting for compilation
-      Compilation mode
-      ◯ (disabled) Debug The Elm debugger isn't available at this point.
-      ◯ (disabled) Standard
-      ◯ (disabled) Optimize
-      ↑↗
-      ·→
-      ▲ ⏳ 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Waiting for compilation
-      Compilation mode
-      ◯ (disabled) Debug The Elm debugger isn't available at this point.
-      ◉ (disabled) Standard
-      ◯ (disabled) Optimize
-      ↑↗
-      ·→
-      ▲ ⏳ 13:10:05 HtmlMain
-      ================================================================================
-      ▼ 🔌 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Connecting
-      attempt 1
-      sleep 1.01 seconds
-      [Connecting web socket…]
-      ▲ 🔌 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Connecting
-      attempt 1
-      sleep 1.01 seconds
-      [Connecting web socket…]
-      ▲ 🔌 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Waiting for compilation
-      Compilation mode
-      ◯ (disabled) Debug The Elm debugger isn't supported by \`Html\` programs.
-      ◉ (disabled) Standard
-      ◯ (disabled) Optimize
-      ↑↗
-      ·→
-      ▲ ⏳ 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Successfully compiled
-      Compilation mode
-      ◯ (disabled) Debug The Elm debugger isn't supported by \`Html\` programs.
-      ◉ Standard
-      ◯ Optimize
-      ↑↗
-      ·→
-      ▲ ✅ 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Waiting for compilation
-      window.Elm does not look like expected! This is the error message:
-      At root:
-      Very unexpected error
-      ↑↗
-      ·→
-      ▲ ⏳ 13:10:05 HtmlMain
-      ================================================================================
-      target HtmlMain
-      elm-watch %VERSION%
-      web socket ws://localhost:59123
-      updated 2022-02-05 13:10:05
-      status Waiting for compilation
-      window.Elm does not look like expected! This is the error message:
-      At root:
-      Very unexpected error
-      ↑↗
-      ·→
-      ▲ ⏳ 13:10:05 HtmlMain
-      ================================================================================
+    expect(onlyExpandedRenders).toMatchInlineSnapshot(`
       target HtmlMain
       elm-watch %VERSION%
       web socket ws://localhost:59123

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -1424,7 +1424,8 @@ describe("hot reloading", () => {
     }
   });
 
-  test("Unexpected/unhandled error at eval", async () => {
+  // TODO: Remove? Have to change it for code coverage?
+  test.skip("Unexpected/unhandled error at eval", async () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalPromiseReject = Promise.reject;
 

--- a/tests/fixtures/hot/missing-window-elm/postprocess.js
+++ b/tests/fixtures/hot/missing-window-elm/postprocess.js
@@ -1,6 +1,5 @@
 export default function postprocess({ code }) {
-  // Make the Elm JS put `.Elm` on a local object instead of on `window`.
-  // This can happen if you try to `import` a JS file created by `elm make`
-  // and your bundler rewrites `this`.
-  return code.replace(/\bthis\b([\W\s]+)$/, "{}$1");
+  // Change from `window.Elm` to `window.NotElm.Elm`, to show that
+  // elm-watch isn’t dependent on `window.Elm` existing.
+  return code.replace(/\bthis\b([\W\s]+)$/, "window.NotElm$1");
 }


### PR DESCRIPTION
- Allows for postprocessing the Elm JS into ESM.
- Avoids encoding reload reasons in a thrown error message.
- A step towards https://github.com/ryan-haskell/vite-plugin-elm-watch being able to use elm-watch as a library. (It currently has some changes to the copied elm-watch code.)