### PR TITLE
fix(example): add missing dependency howler

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,6 +11,7 @@
         "elm-tooling": "1.16.0",
         "elm-watch": "file:../build",
         "esbuild": "0.25.8",
+        "howler": "2.2.4",
         "run-pty": "5.0.0"
       }
     },
@@ -836,6 +837,13 @@
         "@esbuild/win32-ia32": "0.25.8",
         "@esbuild/win32-x64": "0.25.8"
       }
+    },
+    "node_modules/howler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
+      "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-pty": {
       "version": "5.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,7 @@
     "elm-tooling": "1.16.0",
     "elm-watch": "file:../build",
     "esbuild": "0.25.8",
+    "howler": "2.2.4",
     "run-pty": "5.0.0"
   }
 }


### PR DESCRIPTION
Needed to avoid:
```console
$ npm run esbuild -- --serve=9000 --servedir=public

> esbuild
> esbuild app.ts public/submodules/codebase-ui/src/unisonShare.js public/submodules/seeds-game/src/index.ts --bundle --outdir=public/build --public-path=/build/ --loader:.svg=file --loader:.woff2=file --loader:.mp3=file --serve=9000 --servedir=public


 > Local:   http://127.0.0.1:9000/
 > Network: http://192.168.4.100:9000/
 > Network: http://10.0.0.10:9000/
 > Network: http://172.16.0.1:9000/

✘ [ERROR] Could not resolve "pepjs"

    public/submodules/seeds-game/src/index.ts:2:7:
      2 │ import "pepjs";
        ╵        ~~~~~~~

  You can mark the path "pepjs" as external to exclude it from the bundle, which
  will remove this error and leave the unresolved path in the bundle.

✘ [ERROR] Could not resolve "howler"

    public/submodules/seeds-game/src/ts/audio.ts:1:21:
      1 │ import { Howl } from "howler";
        ╵                      ~~~~~~~~

  You can mark the path "howler" as external to exclude it from the bundle, which
  will remove this error and leave the unresolved path in the bundle.

2 errors
```