### PR TITLE
Fix `List.sortWith` breaking in edge case after hot reloading

### DIFF
--- a/src/Inject.ts
+++ b/src/Inject.ts
@@ -18,7 +18,7 @@ import {
 // The regex is anchored to the beginning of lines, which should make it
 // impossible to match within strings in the user’s program.
 const REPLACEMENT_REGEX =
-  /^(?:function (F|_Platform_initialize|_Platform_export|_Browser_application|_Scheduler_binding|_Scheduler_step)\(|var (_VirtualDom_init|\$elm\$browser\$Browser\$sandbox|_Platform_worker|_Browser_element|_Browser_document|_Debugger_element|_Debugger_document) =).*\r?\n?\{(?:.*\r?\n)*?\}\)?;?$/gm;
+  /^(?:function (F|_Platform_initialize|_Platform_export|_Browser_application|_Scheduler_binding|_Scheduler_step)\(|var (_VirtualDom_init|\$elm\$browser\$Browser\$sandbox|_Platform_worker|_Browser_element|_Browser_document|_Debugger_element|_Debugger_document|_List_sortWith) =).*\r?\n?\{(?:.*\r?\n)*?\}\)?;?$/gm;
 
 // Some object properties are marked with `%`, like `%prop%`. They need to be
 // replaced with shorter names in `optimize` mode.
@@ -709,6 +709,26 @@ function _Scheduler_step(proc)
 		}
 	}
 }
+  `.trim(),
+
+  // ### _List_sortWith
+  // This is the only place (that I have found) where Elm compares custom type variants
+  // with `===` object identity, instead of comparing the tags (`.$`). This is not good
+  // for hot reloading, because if you hold on to references to `LT`, `GT` or `EQ` in the model –
+  // either directly or indirectly via a function such as `compare` – `List.sortWith` won’t
+  // work with those after a hot reload. The “new” `List.compare` has references to new
+  // `LT`, `GT` and `EQ` objects, while the model has references to old such objects,
+  // which are equivalent but not the same object instances.
+  _List_sortWith: `
+// This function was slightly modified by elm-watch.
+var _List_sortWith = F2(function(f, xs)
+{
+	return _List_fromArray(_List_toArray(xs).sort(function(a, b) {
+		var ord = A2(f, a, b);
+		// return ord === $elm$core$Basics$EQ ? 0 : ord === $elm$core$Basics$LT ? -1 : 1; // commented out by elm-watch
+		return ord.$ === $elm$core$Basics$EQ.$ ? 0 : ord.$ === $elm$core$Basics$LT.$ ? -1 : 1; // added by elm-watch
+	}));
+});
   `.trim(),
 };
 

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -2214,6 +2214,42 @@ describe("hot reloading", () => {
     }
   });
 
+  test.only("List.sortWith bug", async () => {
+    const { replace, go } = runHotReload({
+      name: "SortWithBug",
+      programType: "Sandbox",
+      compilationMode: "standard",
+      isTTY: false,
+    });
+
+    await go(({ idle, div }) => {
+      switch (idle) {
+        case 1:
+          assertInit(div);
+          replace((content) =>
+            content.replace("hot reload", "simple text change"),
+          );
+          return "KeepGoing";
+        default:
+          assertHotReload(div);
+          return "Stop";
+      }
+    });
+
+    function assertInit(div: HTMLDivElement): void {
+      expect(div.outerHTML).toMatchInlineSnapshot(
+        `<div><div title="hot reload">ab</div></div>`,
+      );
+    }
+
+    function assertHotReload(div: HTMLDivElement): void {
+      // The text in the `div` is supposed to say “ab” (not “ba”) even after the hot reload.
+      expect(div.outerHTML).toMatchInlineSnapshot(
+        `<div><div title="simple text change">ba</div></div>`,
+      );
+    }
+  });
+
   describe("error overlay", () => {
     const fixture = "error-overlay";
     const dir = path.join(FIXTURES_DIR, fixture);

--- a/tests/HotReloading.test.ts
+++ b/tests/HotReloading.test.ts
@@ -2214,7 +2214,7 @@ describe("hot reloading", () => {
     }
   });
 
-  test.only("List.sortWith bug", async () => {
+  test("List.sortWith bug", async () => {
     const { replace, go } = runHotReload({
       name: "SortWithBug",
       programType: "Sandbox",
@@ -2245,7 +2245,7 @@ describe("hot reloading", () => {
     function assertHotReload(div: HTMLDivElement): void {
       // The text in the `div` is supposed to say “ab” (not “ba”) even after the hot reload.
       expect(div.outerHTML).toMatchInlineSnapshot(
-        `<div><div title="simple text change">ba</div></div>`,
+        `<div><div title="simple text change">ab</div></div>`,
       );
     }
   });

--- a/tests/fixtures/hot/hot-reload/elm-watch.json
+++ b/tests/fixtures/hot/hot-reload/elm-watch.json
@@ -165,6 +165,12 @@
                 "src/InitCmds.elm"
             ],
             "output": "build/InitCmds.js"
+        },
+        "SortWithBug": {
+            "inputs": [
+                "src/SortWithBug.elm"
+            ],
+            "output": "build/SortWithBug.js"
         }
     }
 }

--- a/tests/fixtures/hot/hot-reload/src/SortWithBug1.elm
+++ b/tests/fixtures/hot/hot-reload/src/SortWithBug1.elm
@@ -1,0 +1,41 @@
+module SortWithBug1 exposing (main)
+
+import Browser
+import Html exposing (Html)
+import Html.Attributes
+
+
+type alias Msg =
+    ()
+
+
+type alias Model =
+    String -> String -> Order
+
+
+init : Model
+init =
+    compare
+
+
+update : Msg -> Model -> Model
+update () model =
+    model
+
+
+view : Model -> Html Msg
+view model =
+    Html.div [ Html.Attributes.title "hot reload" ]
+        ([ "b", "a" ]
+            |> List.sortWith model
+            |> List.map Html.text
+        )
+
+
+main : Program () Model Msg
+main =
+    Browser.sandbox
+        { init = init
+        , view = view
+        , update = update
+        }


### PR DESCRIPTION
See the code comments in the diff and the added test case.